### PR TITLE
Adding Pt_Br wikipedia page

### DIFF
--- a/en/faq/faqcontributing.md
+++ b/en/faq/faqcontributing.md
@@ -29,6 +29,7 @@ Currently existing pages are:
 * Français: [https://fr.wikipedia.org/wiki/JabRef](https://fr.wikipedia.org/wiki/JabRef)
 * Italiano: [https://it.wikipedia.org/wiki/JabRef](https://it.wikipedia.org/wiki/JabRef)
 * Русский: [https://ru.wikipedia.org/wiki/JabRef](https://ru.wikipedia.org/wiki/JabRef)
+* Portuguese: [https://pt.wikipedia.org/wiki/JabRef](https://pt.wikipedia.org/wiki/JabRef)
 * Svenska: [https://sv.wikipedia.org/wiki/JabRef](https://sv.wikipedia.org/wiki/JabRef)
 * Українська: [https://uk.wikipedia.org/wiki/JabRef](https://uk.wikipedia.org/wiki/JabRef)
 * 中文: [https://zh.wikipedia.org/wiki/JabRef](https://zh.wikipedia.org/wiki/JabRef)


### PR DESCRIPTION
Adding the link to the new JabRef Wikipedia page in Brazilian Portuguese
