### PR TITLE
Copy some documentation from the JabRef source.

### DIFF
--- a/en/finding-sorting-and-cleaning-entries/saveactions.md
+++ b/en/finding-sorting-and-cleaning-entries/saveactions.md
@@ -47,11 +47,18 @@ Cleans up LaTeX code.
 
 ## Normalize date
 
-Normalizes the date to ISO date format.
+Normalizes the date to ISO date format.  Format date string to
+yyyy-mm-dd or yyyy-mm. Keeps the existing String if it does not match
+one of the following formats:
+* "M/y" (covers 9/15, 9/2015, and 09/2015)
+* "MMMM (dd), yyyy" (covers September 1, 2015 and September, 2015)
+* "yyyy-MM-dd" (covers 2009-1-15)
+* "d.M.uuuu" (covers 15.1.2015)
 
 ## Normalize en dashes
 
 Normalizes the en dashes.
+* Replace “` - `” with “` -- `”.
 
 ## Normalize month
 
@@ -59,15 +66,28 @@ Normalize month to BibTeX standard abbreviation.
 
 ## Normalize names of persons
 
-Normalizes lists of persons to the BibTeX standard.
+Normalizes lists of persons to the BibTeX standard. This separates authors by "and"s with first names after last name separated by a commma; first names are not abbreviated.
+* "John Smith" ⇒ "Smith, John"
+* "John Smith and Black Brown, Peter" ⇒ "Smith, John and Black Brown, Peter"
+* "John von Neumann and John Smith and Black Brown, Peter" ⇒ "von Neumann, John and Smith, John and Black Brown, Peter".
 
 ## Normalize page numbers
 
-Normalize pages to BibTeX standard.
+Normalize pages to BibTeX standard. Format page numbers, separated either by commas or double-hyphens.
+Converts the range number format to page_number--page_number. Removes unwanted literals except letters,
+numbers and -+ signs. Keeps the existing String if the resulting field does not match the expected Regex.
 
+    1-2 ⇒ 1--2
+    1,2,3 ⇒ 1,2,3
+    {1}-{2} ⇒ 1--2
+    43+ ⇒ 43+
+    Invalid ⇒ Invalid
+     
 ## Ordinals to LaTeX superscript
 
-Converts ordinals to LaTeX superscripts.
+Converts ordinals to LaTeX superscripts, e.g. 1st, 2nd or 3rd.
+Will replace ordinal numbers even if they are semantically wrong, e.g. 21rd
+* 1st Conf. Cloud Computing -> 1\textsuperscript{st} Conf. Cloud Computing
 
 ## Remove enclosing braces
 
@@ -83,7 +103,7 @@ Removes all line breaks in the field content.
 
 ## Shorten DOI
 
-Shortens DOI to more human readable form.
+Shortens DOI to more human readable form using http://shortdoi.org .
 
 ## Unicode to LaTeX
 
@@ -91,7 +111,10 @@ Converts Unicode characters to LaTeX encoding.
 
 ## Units to LaTeX
 
-Converts units to LaTeX formatting.
+Converts units to LaTeX formatting. This includes: 
+* Add braces around the unit to keep case.
+* Replace hyphen with non-break hyphen
+* Replace space with a hard space
 
 ## Capitalize
 


### PR DESCRIPTION
Some of the save actions need further explanations, either because
BibTeX allows different formattings (like authors) or because it is
completely unclear to the user, whats going on. This improves the
situation a little bit.

Please use <https://docs.jabref.org/> for submitting documentation updates.
