### PR TITLE
Configuration: remove obvious part of the title

### DIFF
--- a/en/setup/README.md
+++ b/en/setup/README.md
@@ -1,4 +1,4 @@
-# Configuration of JabRef
+# Configuration
 
 JabRef can be configured in various ways.
 


### PR DESCRIPTION
For sure, it is about the configuration of JabRef.
so, no need to specify it.