### PR TITLE
General: remove obvious part of the title

### DIFF
--- a/en/general/README.md
+++ b/en/general/README.md
@@ -1,2 +1,2 @@
-# General information about JabRef
+# General information
 


### PR DESCRIPTION
For sure, it is general information about JabRef.
So, no need to specify it.