### PR TITLE
Fix broken link to `how to improve the help page`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository serves the content of <https://docs.jabref.org/> and <https://help.jabref.org/>.
 
-Feel free to improve the page using the [issue tracker](https://github.com/JabRef/help.jabref.org/issues) or by following [our guide](en/faq/how-to-improve-the-help-page.md).
+Feel free to improve the page using the [issue tracker](https://github.com/JabRef/help.jabref.org/issues) or by following [our guide](en/faq/how-tos/how-to-improve-the-help-page.md).
 
 ## How to regenerate SUMMARY.md from scratch
 


### PR DESCRIPTION
The link to [how to improve the help page](https://github.com/JabRef/user-documentation/blob/master/en/faq/how-tos/how-to-improve-the-help-page.md) were broken.