### PR TITLE
FAQ: Filesystem monitoring failure error message.

### DIFF
--- a/en/faqgeneral.md
+++ b/en/faqgeneral.md
@@ -114,3 +114,9 @@ A: After consulting [JabRef's help](https://docs.jabref.org) and checking whethe
 
 A: See [How to improve the help page](faqcontributing/how-to-improve-the-help-page.md).
 
+## Q: "Unable to monitor file changes. Please close files and processes and restart. You may encounter errors if you continue with this session."
+
+A: This error message has been observed on systems that use [inotify](https://www.man7.org/linux/man-pages//man7/inotify.7.html).
+System calls to `inotify_init` and `inotify_add_watch` set `errno` to `EMFILE` when `inotify` has reached its limit. The most
+common reason is that `inotify` is running too many instances. To solve this problem, contact you system administrator and request
+that they increase the limits defined in `/proc/sys/fs/inotify/max_user_*` files.


### PR DESCRIPTION
Provides information on what to do when inotify reaches its limit on Linux systems. Related to https://github.com/JabRef/jabref/pull/6637.