### PR TITLE
Portable version: name of files to launch

### DIFF
--- a/en/installation.md
+++ b/en/installation.md
@@ -14,7 +14,7 @@ Alternatively, on **Windows**, you can use the [chocolatey package manager](http
 
 The portable version of JabRef is designed to be run from a USB stick \(or similar\) with no installation.
 
-Download it from [downloads.jabref.org](https://downloads.jabref.org). These are generic archive files \(e.g., `tar.gz` files for Linux and MacOS, and `zip` files for Windows\) which need to be extracted. Inside the archive files you will find a `bin` subdirectory which contains the binary needed to run JabRef \(i.e., `JabRefMain` for Linux and MacOS, and `JabRefMain.bat` for Windows\).
+Download it from [downloads.jabref.org](https://downloads.jabref.org). These are generic archive files \(e.g., `tar.gz` files for Linux and MacOS, and `zip` files for Windows\) which need to be extracted. Inside the archive files you will find a `bin` subdirectory which contains the binary needed to run JabRef \(i.e., `JabRef` for Linux and MacOS, and `JabRef.exe` for Windows\).
 
 Be sure to activate "Load and Save preferences from/to jabref.xml on start-up \(memory stick mode\)" in Options → Preferences → General.
 

--- a/en/installation.md
+++ b/en/installation.md
@@ -15,6 +15,7 @@ Alternatively, on **Windows**, you can use the [chocolatey package manager](http
 The portable version of JabRef is designed to be run from a USB stick \(or similar\) with no installation.
 
 Download it from [downloads.jabref.org](https://downloads.jabref.org). These are generic archive files \(e.g., `tar.gz` files for Linux and MacOS, and `zip` files for Windows\) which need to be extracted. Inside the archive files you will find the file needed to run JabRef:
+
 - for Windows, this is the file `runtime\bin\JabRef.bat`.
 - for Linux, this is the file `bin\JabRef`.
 - for Mac, this is the file `JabRef.app/Contents/MacOS/Jabref`.

--- a/en/installation.md
+++ b/en/installation.md
@@ -14,7 +14,10 @@ Alternatively, on **Windows**, you can use the [chocolatey package manager](http
 
 The portable version of JabRef is designed to be run from a USB stick \(or similar\) with no installation.
 
-Download it from [downloads.jabref.org](https://downloads.jabref.org). These are generic archive files \(e.g., `tar.gz` files for Linux and MacOS, and `zip` files for Windows\) which need to be extracted. Inside the archive files you will find a `bin` subdirectory which contains the binary needed to run JabRef \(i.e., `JabRef` for Linux and MacOS, and `JabRef.exe` for Windows\).
+Download it from [downloads.jabref.org](https://downloads.jabref.org). These are generic archive files \(e.g., `tar.gz` files for Linux and MacOS, and `zip` files for Windows\) which need to be extracted. Inside the archive files you will find the file needed to run JabRef:
+- for Windows, this is the file `runtime\bin\JabRef.bat`.
+- for Linux, this is the file `bin\JabRef`.
+- for Mac, this is the file `JabRef.app/Contents/MacOS/Jabref`.
 
 Be sure to activate "Load and Save preferences from/to jabref.xml on start-up \(memory stick mode\)" in Options → Preferences → General.
 


### PR DESCRIPTION
The filenames did not match for JabRef 5.0 (or 5.1).