### PR TITLE
Update how-to-improve-the-help-page.md

### DIFF
--- a/en/faqcontributing/how-to-improve-the-help-page.md
+++ b/en/faqcontributing/how-to-improve-the-help-page.md
@@ -1,62 +1,58 @@
-# How to Improve the Help Page
+# How to Improve a Help Page
 
-Here is a quick start guide of how to improve the help page.
+Here is a quick start guide on how to improve help pages in the [Jabref User Documentation](https://docs.jabref.org/).
 
 ## Prerequisite
 
-Our help pages are hosted at [GitBook](https://www.gitbook.com/) with an integration to GitHub., which provides version control based on [git](https://git-scm.com/). In order to edit or create a JabRef help page you need a GitHub account. You can sign up [here](https://github.com/join) for free.
-
-If you already have an account, please make sure that you are signed in.
+The Jabref help pages are hosted at [GitBook](https://www.gitbook.com/) with an integration to GitHub, which provides version control based on [git](https://git-scm.com/). In order to edit or create a JabRef help page, you need a GitHub account. You can sign up [here](https://github.com/join) for free. If you already have an account, please make sure that you are signed in.
 
 ## Editing Help Pages directly in the browser
 
-The easiest way to fix small errors or to add additional information is to edit a JabRef help page directly in your browser:
+The easiest way to fix small errors, or to add additional information, is to edit a help page directly in your browser, using the following steps.
 
-### Start editing
+### 1. Start editing
 
-At the top of each help page you can find the GitHub icon. Just click here to show the source of the page.
+At the top of each help page, you can find the GitHub icon with "Edit on GitHub" link. Just click the link to show the source of the page.
 
-This leads you to GitHub:
+This leads you to the GitHub page associated with the help page:
 
 ![Click on the pencil icon](../.gitbook/assets/screenshot-edit-pencil.png)
 
-To actually edit the page click on the pencil icon which is highlighted above.
+To actually edit the page, click on the pencil icon, as highlighted above.
 
-### Make your changes
+### 2. Make your changes
 
 The window to edit the page at GitHub looks like this:
 
 ![Edit view at GitHub](../.gitbook/assets/screenshot-edit-page.png)
 
-Most text can be simply added in this field as plain text. However, you can style your contribution by using [markdown](https://daringfireball.net/projects/markdown/). Markdown is a rather easy way to format text without the need for complex markup as for example in HTML.
+Most text can be simply added/edited in this field as plain text. However, you can style your contribution by using [markdown](https://daringfireball.net/projects/markdown/). Markdown is a rather easy way to format text without the need for complex markup, such as with HTML. You can find an introduction to markdown [here](https://daringfireball.net/projects/markdown/) or [here](https://guides.github.com/features/mastering-markdown/).
 
-You can find an introduction to markdown [here](https://daringfireball.net/projects/markdown/) or [here](https://guides.github.com/features/mastering-markdown/).
-
-In order to check your changes hit the "Preview Changes" tab:
+In order to review your changes, click on the "Preview changes" tab:
 
 ![Edit view at GitHub](../.gitbook/assets/screenshot-edit-preview.png)
 
-### Saving the changes
+### 3. Saving the changes
 
-To save the changes you have to create a so called "Commit" by scrolling down and hitting the button "Propose File Change":
+To save the changes, create a so called "Commit" by scrolling down and pressing the "Propose File Change" button:
 
 ![Save changes](../.gitbook/assets/screenshot-edit-commit.png)
 
-_Please note: The message you provide here will be visible in the history of the help page, so please think a second to provide a meaningful description of your changes._
+_Please note: The message you provide here will be visible in the history of the help page, so please consider your change and provide a meaningful description of your changes._
 
-As a last step you have to submit the changes you have made back to us:
+As a last step, submit the changes you have made back to the JabRef team:
 
 ![Create Pull Request](../.gitbook/assets/screenshot-edit-pullrequest.png)
 
-Just hit the button "Create Pull Request" and confirm the creation on the next page which is opened by hitting "Create Pull Request".
+Just press the "Create Pull Request" button, and confirm the creation of the request on the next page.
 
-That's it! We'll review your changes and publish them at [docs.jabref.org](https://docs.jabref.org).
+That's it! The JabRef team will review your changes and publish them on [docs.jabref.org](https://docs.jabref.org).
 
 ## Advanced editing
 
-To edit more than one file at a time, to add screenshots, and for other more advanced changes we recommend to checkout this repository locally and to create a PR of your changes using the standard git and GitHub workflow.
+To edit more than one file at a time, add screenshots, and for other more advanced changes, we recommend that you checkout this repository locally and create a Pull Request of your changes using the standard git and GitHub workflow.
 
 ### Tables
 
-The best way to enter tables is to use this [Table generator](http://www.tablesgenerator.com/markdown_tables) for Markdown. It has the nice feature to generate markdown tables from different sources, e.g. you can directly copy the table from a spreadsheet or upload a csv files. Just copy and paste the generated markdown.
+The best way to enter tables is to use this [Table Generator](http://www.tablesgenerator.com/markdown_tables) for Markdown. It has the nice feature to generate markdown tables from different sources, e.g. you can directly copy the table from a spreadsheet or upload a csv file. Just copy and paste the generated markdown into the documentation.
 


### PR DESCRIPTION
Several changes to the text:
* Add commas to ease readability
* Remove superfluous language (e.g. "you have to")
* Add numbers to "Editing Help Pages directly in the browser" subsection headings to make sequential steps clear
* Remove personal pronouns where unnecessary/ambiguous (e.g. "we" -> "The JabRef team")
* Use more precise language (e.g. "hit the button" -> "press the button")
* Fix capitalization to match actual text (e.g. "Preview Changes" -> "Preview changes")
* Other small wording changes