### PR TITLE
Remove recommendation in favour of better style

### DIFF
--- a/en/advanced/fields.md
+++ b/en/advanced/fields.md
@@ -56,7 +56,7 @@ The following fields are recognized by the default bibliography styles:
 * **publisher** The publisher's name.
 * **school** The name of the academic institution where a thesis was written.
 * **series** The name of a series or set of books. When citing an entire book, the `title` field gives its title and an optional `series` field gives the name of a series or multi-volume set in which the book is published.
-* **title** The title of the work. The capitalization may depend on the bibliography style and on the language used. For words that have to be capitalized \(such as a proper noun\), enclose the word \(or its first letter\) in braces.
+* **title** The title of the work. The capitalization may depend on the bibliography style and on the language used. For words that have to be capitalized \(such as a proper noun\), enclose the word in braces.
 * **type** The type of a technical report - for example, "Research Note".
 * **volume** The volume of a journal or multivolume book.
 * **year** The year of publication or, for an unpublished work, the year it was written. Generally it should consist of four numerals, such as `1984`, although the standard styles can handle any `year` whose last four nonpunctuation characters are numerals, such as "\(about 1984\)". This field is required for most entry types.


### PR DESCRIPTION
I followed the link from the Save Actions page, and found this:
https://tex.stackexchange.com/a/10775
According to that post, protecting just the first letter of a word, might lead to bad spacing after the capital letter.
This might be a bit perfectionist, but I would suggest leaving the recommendation in brackets out, to be consistent.