### PR TITLE
Add snap/flatpak information

### DIFF
--- a/en/installation.md
+++ b/en/installation.md
@@ -65,6 +65,14 @@ The integration with TeX editors is fine if JabRef is a deb/rpm, and the editor 
 
 Depending on your use case and needed integrations it is advisable to choose the proper packages. Watch this page for new developments on the interactions with external programs.
 
+|                       | Snap | Flatpak | deb/rpm            | tar                |
+|-----------------------|------|---------|--------------------|--------------------|
+| Libreoffice (system)  | :x:  | :x:     | :heavy_check_mark: | :heavy_check_mark: |
+| Libreoffice (snap)    | :x:  | :x:     | :x:                | :x:                |
+| Libreoffice (flatpak) | :x:  | :x:     | :x:                | :x:                |
+| LaTex editor (system) | :x:  | :x:     | :heavy_check_mark: | :heavy_check_mark: |
+| LaTeX editor (snap)   | :x:  | :x:     | :heavy_check_mark: | :heavy_check_mark: |
+
 ### Include JabRef in the start menu of Ubuntu
 
 See [http://askubuntu.com/a/721387/196423](http://askubuntu.com/a/721387/196423) for details.

--- a/en/installation.md
+++ b/en/installation.md
@@ -56,6 +56,15 @@ Use [AutoHotkey](http://www.autohotkey.com/) and [JabRef.ahk](https://github.com
 
 The connection from JabRef to Libre Office requires some office related `jar`-archives to be present. For this, you have to install the package `libreoffice-java-common`.
 
+### External program integration in Snap and Flatpak packages
+
+The snap and flatpak packages cannot interact directly with external programs (i.e. programs not contained in the package sandbox).
+What this means is that for now there is no possible connection between JabRef and Libreoffice if either one is a snap/flatpak.
+
+The integration with TeX editors is fine if JabRef is a deb/rpm, and the editor is a snap/deb/rpm (not a flatpak).
+
+Depending on your use case and needed integrations it is advisable to choose the proper packages. Watch this page for new developments on the interactions with external programs.
+
 ### Include JabRef in the start menu of Ubuntu
 
 See [http://askubuntu.com/a/721387/196423](http://askubuntu.com/a/721387/196423) for details.


### PR DESCRIPTION
Add information related to the integration between jabref and external programs.
It might be a good idea to add a table with checks that can easily visualize the possible connections..

Something like this:
||Snap|Flatpak|deb/rpm|portable|
|Libreoffice|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|

Granted, it's not shown properly as markdown in the comment..but is it a good idea or is it just lost space on the page?