### PR TITLE
Add notice of chrome extension not working in Edge

### DIFF
--- a/en/collect/jabref-browser-extension.md
+++ b/en/collect/jabref-browser-extension.md
@@ -18,6 +18,8 @@ Normally, you simply install the extension from the browser store and are ready 
 
 > [Firefox](https://addons.mozilla.org/en-US/firefox/addon/jabref/?src=external-github) - [Chrome](https://chrome.google.com/webstore/detail/jabref-browser-extension/bifehkofibaamoeaopjglfkddgkijdlh) - [Edge](https://microsoftedge.microsoft.com/addons/detail/pgkajmkfgbehiomipedjhoddkejohfna) - [Vivaldi](https://chrome.google.com/webstore/detail/jabref-browser-extension/bifehkofibaamoeaopjglfkddgkijdlh)
 
+While Chrome extensions can work in Edge (and will install), JabRef is configured to work with the Edge extension in the Edge Browser, and the Chrome extension in the Chrome Browser. It will not work if they are mixed.
+
 Most JabRef installations include the necessary files, so test the extension before proceeding with the following instructions. However, sometimes, a manual installation is necessary \(e.g. if you use the portable version of JabRef\). In this case, please take the following steps:
 
 ### Windows


### PR DESCRIPTION
At the moment in Edge one has to install the extension from the edge store..
The chrome extension can be installed, but it will not work.
I added a warning in the documentation about this.
The alternative would be to replicate the settings for the chrome extension in edge as well, to enable them both.
This would entail adding the chrome extension on install also in the edge path on all systems.