### PR TITLE
add a more remarkable pasting tip.

### DIFF
--- a/en/collect/add-entry-using-an-id.md
+++ b/en/collect/add-entry-using-an-id.md
@@ -6,8 +6,6 @@ description: Create an entry based on an ID such as DOI or ISBN.
 
 ## From an ID to an entry
 
-Simply paste the DOI into the table of entry, and JabRef will create the new corresponding entry.
-
 For other identifiers, choose **Library → New entry**, or click on the `New entry` button, or use the keyboard shortcut `CTRL + N`. In the lower part of the window, there are two boxes : "ID type" and "ID". In the field "ID type", you can select the desired identifier, e.g. "ISBN" \(it works also for DOI\). Then enter the identifier in the textbox below and press Enter. That will generate an entry based on the given ID \(you can also click on "Generate"\). The entry is added to your library and opened in the entry editor. In case an error occurs, a popup is shown.
 
 ![Window for selecting an entry type or the ID of an entry. Note: the actual content of the dialog depends on the database mode \(BibTeX or biblatex\). ](../.gitbook/assets/jabref-5.3-selectentrytype.png)
@@ -15,6 +13,8 @@ For other identifiers, choose **Library → New entry**, or click on the `New en
 {% hint style="info" %}
 Sometimes the new entry contains a `url` field. This field usually points to the URL of the book at the respective online book store. In case you buy the book using this link, the service provider \(e.g., [ebook.de](https://www.ebook.de)\) receive a commission to fund the service.
 {% endhint %}
+
+{% hint style="info" %} You can also add an entry by simply pasting its BibTex or its DOI from your clipboard to the maintable. {% endhint %}
 
 ## Supported databases
 


### PR DESCRIPTION
Fixes #296 

I removed the normal text for pasting ref IDs and replace it with a more noticeable tip box. I also attached the screenshot.
![image](https://user-images.githubusercontent.com/62237588/124717287-2f99d600-df2f-11eb-9862-32011dc33a8d.png)
Please make a consideration.
