### PR TITLE
Clarify how to use hyphenated icons

### DIFF
--- a/en/finding-sorting-and-cleaning-entries/groups.md
+++ b/en/finding-sorting-and-cleaning-entries/groups.md
@@ -61,7 +61,7 @@ A description of the group, to help you remember what it is about. This descript
 
 ### Icon and color
 
-An icon can be displayed in front of the group name. Choose your favorite icon among the ones available at [https://materialdesignicons.com/](https://materialdesignicons.com/), and enter its name of the field _Icon_. The color of the icon can be set in the field _Color_.
+An icon can be displayed in front of the group name. Choose your favorite icon among the ones available at [https://materialdesignicons.com/](https://materialdesignicons.com/), and enter its name of the field _Icon_ \(replacing any hyphens \(`-`\) with underscores \(`_`\)). The color of the icon can be set in the field _Color_.
 
 ![](../.gitbook/assets/groups-groupwindow-iconcolorhierarchy-jabref5.2.png)
 


### PR DESCRIPTION
Add clarification on how to use icons that have hyphens in their name (e.g.`robot-love`). Specifying `robot-love` as an icon is invalid and keeps the default circle icon without any indication as to what's wrong, while `robot_love` correctly shows the `robot-love` icon. 
I wasn't sure about how to quote\highlight the individual characters (`-`, `_` or '-' and '_'), feel free to (ask me to) change it ![image](https://user-images.githubusercontent.com/15890747/131348484-b63e36cc-da1a-4200-9934-0e12da33a63b.png)
