### PR TITLE
Update jabref-browser-extension.md with notes for local MacOS installs

### DIFF
--- a/en/collect/jabref-browser-extension.md
+++ b/en/collect/jabref-browser-extension.md
@@ -153,3 +153,8 @@ Most JabRef installations include the necessary files, so test the extension bef
       When using the Stable release/channel, {Channel\_Name} is not required.
 
 3. Check that the Python script works. In Terminal run `/Applications/JabRef.app/Contents/Resources/jabrefHost.py`. If there are no errors the script is working properly. Stop the script by pressing `Ctrl + D`.
+
+#### Local JabRef installs
+
+org.jabref.jabref.json directs the browser extension to a python script in the JabRef app, which is set to the most common install path by default (`/Applications/JabRef.app/Contents/Resources/jabrefHost.py`). If you have installed JabRef somewhere else, most likely to your local applications folder (`~/Applications/JabRef`), then you will need to update this path to the correct location. For example, in local installs this would be `/Users/USER/Applications/JabRef.app/Contents/Resources/jabrefHost.py`, where `USER` is your username.
+


### PR DESCRIPTION
Fixes JabRef issue [9474](https://github.com/JabRef/jabref/issues/9474).

As mentioned in the issue thread and accompanying [PR](https://github.com/JabRef/jabref/pull/9487), several hardcoded paths fail in the app is installed to users local `~/Applications` directory, for example if installing without admin rights. This PR adds notes to the docs pointing users to update the JSON file to point to the correct app location if needed.

If the accompanying python script PR isn't merged the documents could be further expanded to direct the user to also update the hardcoded MacOS app path contained in that script.