### PR TITLE
Describe how to (re)set default file opening application for snap on Linux

### DIFF
--- a/en/installation.md
+++ b/en/installation.md
@@ -83,10 +83,11 @@ Depending on your use case and needed integrations it is advisable to choose the
 
 #### Change default application to open files for JabRef snap
 
-When JabRef is installed as a snap, it initially asks which application should be use to open PDFs (or other files). However, after selecting the same application three times, that application is set as default and there is no obvious way to select another application ("Preferences" -> "External File Types" does not help here, because the snap sandbox does not "see" any of the user's applications).
-This setting is stored in the XDG permission storage, and can be changed with a command like the following (see [this forum thread](https://forum.snapcraft.io/t/xdg-permissions-stores-should-be-configurable-with-snapd/25048) for further information):
+When JabRef is installed as a snap, it initially asks which application should be used to open PDFs (or other files). However, after selecting the same application three times, that application is set as default and there is no obvious way to select another application ("Preferences" -> "External File Types" does not help here, because the snap sandbox does not "see" any of the user's applications).
+This setting is stored in the XDG permission storage, and can be changed with a command like the following (see [this forum thread](https://forum.snapcraft.io/t/xdg-permissions-stores-should-be-configurable-with-snapd/25048) for further information, and have a look at `flatpack permissions` to find the correct "Table": look for a line where the "App" is `snap.jabref` - in the below example, the table is the default `desktop-used-apps`):
 `flatpak permission-set --data "{'always-ask':<false>}" desktop-used-apps application/pdf snap.jabref okularApplication_pdf 0 3`
 In this example, the default application to open PDF files is set to `okularApplication_pdf`, and the counter for when to stop asking how to open PDF files is set to 0/3.
+If you want JabRef to ask you which application to use every time, use `'always-ask':<true>` in the `data` parameter.
 
 #### Include JabRef in the start menu of Ubuntu
 

--- a/en/installation.md
+++ b/en/installation.md
@@ -81,6 +81,13 @@ Depending on your use case and needed integrations it is advisable to choose the
 | LyX                   | ❌    | ✅       | ✅       | ✅   |
 | Vim/Emacs             | ❌    | ❌       | ✅       | ✅   |
 
+#### Change default application to open files for JabRef snap
+
+When JabRef is installed as a snap, it initially asks which application should be use to open PDFs (or other files). However, after selecting the same application three times, that application is set as default and there is no obvious way to select another application ("Preferences" -> "External File Types" does not help here, because the snap sandbox does not "see" any of the user's applications).
+This setting is stored in the XDG permission storage, and can be changed with a command like the following (see [this forum thread](https://forum.snapcraft.io/t/xdg-permissions-stores-should-be-configurable-with-snapd/25048) for further information):
+`flatpak permission-set --data "{'always-ask':<false>}" desktop-used-apps application/pdf snap.jabref okularApplication_pdf 0 3`
+In this example, the default application to open PDF files is set to `okularApplication_pdf`, and the counter for when to stop asking how to open PDF files is set to 0/3.
+
 #### Include JabRef in the start menu of Ubuntu
 
 See [http://askubuntu.com/a/721387/196423](http://askubuntu.com/a/721387/196423) for details.


### PR DESCRIPTION
I had this problem and it took me a long time to figure out what was going on.
I do realize that in its current state, the example command given is probably not optimal, but I currently do not have the time to look further into the `flatpak` CLI docs etc. to give more general guidance.

Maybe somebody has more experience with that and can improve on my initial wording.