### PR TITLE
Change "Key bindings" to "Keyboard shortcuts"

### DIFF
--- a/en/setup/customkeybindings.md
+++ b/en/setup/customkeybindings.md
@@ -1,7 +1,7 @@
-# Customize key bindings
+# Customize keyboard shortcuts
 
-This feature is available through **File → Preferences → Key bindings**.
+This feature is available through **File → Preferences → Keyboard shortcuts*.
 
-You can reset the key bindings to default by pressing the "Default" button. This is especially useful when upgrading from a JabRef version before 3.8.2.
+You can reset the keyboard shortcuts to default by pressing the "Default" button. This is especially useful when upgrading from a JabRef version before 3.8.2.
 
 ![](../.gitbook/assets/keybindings.png)


### PR DESCRIPTION
This change follows this [PR](https://github.com/JabRef/jabref/pull/11153). It updates the page about [key bindings](https://docs.jabref.org/setup/customkeybindings) to use "keyboard shortcuts" instead. 
