### PR TITLE
Replace "key bindings" with "keyboard shortcuts"

### DIFF
--- a/en/advanced/commandline.md
+++ b/en/advanced/commandline.md
@@ -224,7 +224,7 @@ Display the version number of JabRef.
 
 ### Debug mode: `--debug`
 
-Show debug level messages. The log files are stored in an internal file. See FAQs for [Windows](https://docs.jabref.org/faq/windows#q-where-can-i-find-jabrefs-log-files), [Linux](https://docs.jabref.org/faq/linux#where-can-i-find-jabrefs-log-files), [macOS ](https://docs.jabref.org/faq/osx#q-where-can-i-find-jabrefs-log-files)depending on your OS where to find it.
+Show debug level messages. The log files are stored in an internal file. See FAQs for [Windows](https://docs.jabref.org/faq/windows#q-where-can-i-find-jabrefs-log-files), [Linux](https://docs.jabref.org/faq/linux#where-can-i-find-jabrefs-log-files), [macOS](https://docs.jabref.org/faq/osx#q-where-can-i-find-jabrefs-log-files)depending on your OS where to find it.
 
 ### Display output in the console: `--console`
 

--- a/en/advanced/commandline.md
+++ b/en/advanced/commandline.md
@@ -224,7 +224,7 @@ Display the version number of JabRef.
 
 ### Debug mode: `--debug`
 
-Show debug level messages. The log files are stored in an internal file. See FAQs for [Windows](https://docs.jabref.org/faq/windows#q-where-can-i-find-jabrefs-log-files), [Linux](https://docs.jabref.org/faq/linux#where-can-i-find-jabrefs-log-files), [macOS](https://docs.jabref.org/faq/osx#q-where-can-i-find-jabrefs-log-files)depending on your OS where to find it.
+Show debug level messages. The log files are stored in an internal file. See FAQs for [Windows](https://docs.jabref.org/faq/windows#q-where-can-i-find-jabrefs-log-files), [Linux](https://docs.jabref.org/faq/linux#where-can-i-find-jabrefs-log-files), [macOS](https://docs.jabref.org/faq/osx#q-where-can-i-find-jabrefs-log-files) depending on your OS where to find it.
 
 ### Display output in the console: `--console`
 

--- a/en/advanced/fields.md
+++ b/en/advanced/fields.md
@@ -38,12 +38,12 @@ There is a lot of different fields in _BibTeX_, and some additional fields that 
 
 The following fields are recognized by the default bibliography styles:
 
-*   **bibtexkey** A unique string used to refer to the entry in LaTeX documents. Note that when referencing an entry from LaTeX, the key must match case-sensitively with the reference string. Some characters should not be used in bibtexkey as they are not compatible or not recommended:
+* **bibtexkey** A unique string used to refer to the entry in LaTeX documents. Note that when referencing an entry from LaTeX, the key must match case-sensitively with the reference string. Some characters should not be used in bibtexkey as they are not compatible or not recommended:
 
     `{ } ( ) , \ " - # ~ ^ : '`
 * **address** Usually the address of the `publisher` or other type of institution. For major publishing houses, you may omit the information entirely or give simply the city. For small publishers, on the other hand, you can help the reader by giving the complete address.
 * **annote** An annotation. It is not used by the standard bibliography styles, but may be used by others that produce an annotated bibliography.
-*   **author** This field should contain the complete author list for your entry. The names are separated by the word _and_, even if there are more than two authors. Each name can be written in two equivalent forms:
+* **author** This field should contain the complete author list for your entry. The names are separated by the word _and_, even if there are more than two authors. Each name can be written in two equivalent forms:
 
     Donald E. Knuth _or_ Knuth, Donald E.
 
@@ -61,7 +61,7 @@ The following fields are recognized by the default bibliography styles:
 * **key** Used for alphabetizing, cross referencing, and creating a label when the \`\`author'' information is missing. This field should not be confused with the key that appears in the `\cite` command and at the beginning of the library entry.
 * **month** The month in which the work was published or, for an unpublished work, in which it was written. You should use the standard three-letter abbreviation of the English names (jan, feb, mar, apr, may, jun, jul, aug, sep, oct, nov, dec).
 * **note** Any additional information that can help the reader. The first word should be capitalized.
-*   **number**
+* **number**
 
     The number of a journal, magazine, technical report, or of a work in a series. An issue of a journal or magazine is usually identified by its volume and number; the organization that issues a technical report usually gives it a number; and sometimes books are given numbers in a named series.
 * **organization** The organization that sponsors a conference or that publishes a manual.
@@ -120,7 +120,7 @@ You can create new fields by [editing (or creating) entry types](../setup/custom
 ## Hints on fields
 
 * Generally, you can use LaTeX commands inside of fields containing text. _BibTeX_ will automatically format your reference lists, and those fields that are included in the lists will be (de)capitalized according to your bibliography style. To ensure that certain characters remain capitalized, enclose them in braces, like in the word _{B}elgium_.
-*   An institution name should be inside `{}` brackets.
+* An institution name should be inside `{}` brackets.
 
     If the institution name also includes its abbreviation, this abbreviation should be also in `{}` brackets.
 

--- a/en/setup/customkeybindings.md
+++ b/en/setup/customkeybindings.md
@@ -1,7 +1,7 @@
-# Customize key bindings
+# Customize keyboard shortcuts
 
-This feature is available through **File → Preferences → Key bindings**.
+This feature is available through **File → Preferences → Keyboard shortcuts**.
 
-You can reset the key bindings to default by pressing the "Default" button. This is especially useful when upgrading from a JabRef version before 3.8.2.
+You can reset the keyboard shortcuts to default by pressing the "Default" button. This is especially useful when upgrading from a JabRef version before 3.8.2.
 
 ![](../.gitbook/assets/keybindings.png)


### PR DESCRIPTION
This PR updates the user documentation to match the [PR #11153](https://github.com/JabRef/jabref/pull/11153) from the original JabRef repo. It only changes the name "key bindings" to "keyboard shortcuts" in the according documentation. 