### PR TITLE
Update and fix typo in citationkeypatterns.md

### DIFF
--- a/en/setup/citationkeypatterns.md
+++ b/en/setup/citationkeypatterns.md
@@ -108,7 +108,7 @@ Generally, modifiers are applied in the order they are specified. In the followi
 * **`:truncateN`**: Truncates the string after the N:th character and trims any trailing whitespaces. For example, **`[fulltitle:truncate3]`** will convert `A Title` to `A T`.
 * **`:sentencecase`**: Changes the first character of the first word to uppercase, all remaining words are converted to lowercase. Example: `an Example Title` will be converted to `An example title`
 * **`:regex("pattern", "replacement")`**: Applies regular expression pattern matching and replacement. For example,
-  * **`[auth.etal:regex("\\.etal","EtAl"):regex("\\.","And")]`**, the first `regex()` replaces `.etal` with `EtAl`. The second `regex()` replaces the `.` between entries with two authors with \`And
+  * **`[auth.etal:regex("\\.etal","EtAl"):regex("\\.","And")]`** will extract the last name of the first author, and the last name of the second author, if there are two authors or .etal if there are more than two. The first `regex()` replaces `.etal` with `EtAl`. The second `regex()` replaces any `.` between entries with two authors with `And`. 
 * **`:(x)`**: The string between the parentheses will be inserted if the field marker preceding this modifier resolves to an empty value. The placeholder `x` may be any string. For instance, the marker **`[VOLUME:(unknown)]`** will return the entry's volume if set, and the string **unknown** if the entry's `VOLUME` field is not set
 
 ### Formatters

--- a/en/setup/citationkeypatterns.md
+++ b/en/setup/citationkeypatterns.md
@@ -108,8 +108,8 @@ Generally, modifiers are applied in the order they are specified. In the followi
 * **`:truncateN`**: Truncates the string after the N:th character and trims any trailing whitespaces. For example, **`[fulltitle:truncate3]`** will convert `A Title` to `A T`.
 * **`:sentencecase`**: Changes the first character of the first word to uppercase, all remaining words are converted to lowercase. Example: `an Example Title` will be converted to `An example title`
 * **`:regex("pattern", "replacement")`**: Applies regular expression pattern matching and replacement. For example,
-  * **`[auth.etal:regex("\\.etal","EtAl"):regex("\\.","And")]`** will extract the last name of the first author, and the last name of the second author, if there are two authors or .etal if there are more than two. The first `regex()` replaces `.etal` with `EtAl`. The second `regex()` replaces any `.` between entries with two authors with `And`. 
-* **`:(x)`**: The string between the parentheses will be inserted if the field marker preceding this modifier resolves to an empty value. The placeholder `x` may be any string. For instance, the marker **`[VOLUME:(unknown)]`** will return the entry's volume if set, and the string **unknown** if the entry's `VOLUME` field is not set
+  * **`[auth.etal:regex("\\.etal","EtAl"):regex("\\.","And")]`** will extract the last name of the first author, and the last name of the second author, if there are two authors or .etal if there are more than two. The first `regex()` replaces `.etal` with `EtAl`. The second `regex()` replaces any `.` between entries with two authors with `And`.
+* **`:(x)`**: The string between the parentheses will be inserted if the field marker preceding this modifier resolves to an empty value. The placeholder `x` may be any string. For instance, the marker **`[VOLUME:(unknown)]`** will return the entry's volume if set, and the string **unknown** if the entry's `VOLUME` field is not set.
 
 ### Formatters
 


### PR DESCRIPTION
Small update to explanation of `:regex("pattern", "replacement")`