### PR TITLE
Add Linux Mint LibreOffice DEB Application Path

### DIFF
--- a/en/cite/openofficeintegration.md
+++ b/en/cite/openofficeintegration.md
@@ -14,6 +14,8 @@ To communicate with OpenOffice, JabRef must first connect to a running OpenOffic
 
 JabRef needs to know the location of your OpenOffice executable (**soffice.exe** on Windows, and **soffice** on other platforms), and the directory where several OpenOffice jar files reside. If you connect by clicking the **Connect** button, JabRef will try to automatically determine these locations. If this does not work, you need to connect using the **Manual connect** button, which will open a window asking you for the needed locations.
 
+If you are one of the rare users that have manually installed LibreOffice via a [deb](https://de.wikipedia.org/w/index.php?title=Debian-Paket&oldid=244262361) file in Linux Mint (an Ubuntu based distribution), you can choose the LibreOffice directory under `/opt/`. For example `/opt/libreoffice24.2/`. In this particular case, it is enough to choose the directory path. Finding the soffice file is not required. Note that installing deb files manually is not recommended. If you can, use the package manager of your distribution.
+
 After the connection has been established, you can insert citations by selecting one or more entries in JabRef and using the **Push to OpenOffice** button in the dropdown menu of JabRef's toolbar, or by using the appropriate button in the OpenOffice panel in the side pane. This will insert citations for the selected entries at the current cursor position in the OpenOffice document, and update the bibliography to contain the full reference.
 
 ![](<CiteLibreOffice (3).gif>)


### PR DESCRIPTION
When LibreOffice was manually installed via a deb file, the path is in an odd location and hard to find. I added this path to the documentation. Usually, it is not recommended for users of Linux Mint to install deb files manually (The package manager and Flatpak are better choices), but some users on long term supported distributions may be tempted to install the newest version of LibreOffice that way, as the package manager may not feature new versions.