### PR TITLE
Amend user docs per code repo PR #12037

### DIFF
--- a/en/collaborative-work/sharedbibfile.md
+++ b/en/collaborative-work/sharedbibfile.md
@@ -7,7 +7,7 @@ _Note:_ the use of a version control system \(SVN, git, etc.\) is recommended as
 To make the sharing of a Bib\(la\)TeX library easier, it is recommended to set specific library properties. In the menu **Library → Library properties**:
 
 * Select `UTF-8` as encoding.
-* Define a `General file directory`, which will be used to store shared PDF \(and other\) files.
+* Define a `Library-specific file directory`, which will be used to store shared PDF \(and other\) files.
 * Check  `Refuse to save the library before external changes have been reviewed`.
 * Define a sort order \(`year`, `author`, `title` is recommended\)..
 * Check `Enable save formatters`, and defines these actions, to help enforcing a consistent format for the entries.

--- a/en/faq/README.md
+++ b/en/faq/README.md
@@ -82,11 +82,11 @@ A: Yes, you can use the parameter `--importToOpen bibfile` of the [command line]
 
 ## Q: How do I link external files with paths relative to my .bib file, so I can move my library along with its files to another directory?
 
-A: You need to override the default file directory for this specific library. In **Library → Library properties** you can override the **Default file directory** setting. There, you can either enter the path in **General file directory** (for it to be valid for all users of the file) or in **User-specific file directory** (for it to be valid for you only). If you simply enter “.” (a dot, without the quotes), the file directory will be the same as the .bib file directory. To place your files in a subdirectory called **subdir**, you can enter **“./subdir”** (without the quotes). Files will automatically be linked with relative paths if the files are placed in the default file directory or in a directory below it. More details on the [help page about the library properties](../setup/databaseproperties.md).
+A: You need to override the default file directory for this specific library. In **Library → Library properties** you can override the **Default file directory** setting. There, you can either enter the path in **Library-specific file directory** (for it to be valid for all users of the file) or in **User-specific file directory** (for it to be valid for you only). If you simply enter “.” (a dot, without the quotes), the file directory will be the same as the .bib file directory. To place your files in a subdirectory called **subdir**, you can enter **“./subdir”** (without the quotes). Files will automatically be linked with relative paths if the files are placed in the default file directory or in a directory below it. More details on the [help page about the library properties](../setup/databaseproperties.md).
 
 ## Q: Can I use a bib-file specific PDF directory?
 
-A: In **Library → Library properties** you can choose a library-specific directory in the field “General file directory”. If you want to set a directory only for you (so that other users should use the default directory), use the field “User-specific file directory”.
+A: In **Library → Library properties** you can choose a library-specific directory in the field “Library-specific file directory”. If you want to set a directory only for you (so that other users should use the default directory), use the field “User-specific file directory”.
 
 ## Q: How do I export my bibliography entries into a simple text file, so I can import them into a spreadsheet (in LibreOffice, OpenOffice, MS Office, etc.)?
 

--- a/en/finding-sorting-and-cleaning-entries/filelinks.md
+++ b/en/finding-sorting-and-cleaning-entries/filelinks.md
@@ -17,21 +17,21 @@ JabRef offers the following directory settings:
 1. **File → Preferences → Linked files**, item _Main file directory._
 
     <img src="../.gitbook/assets/preferences-linkedfiles-5.2.png" alt="Main file directory" data-size="original">
-2. **Library → Library properties**, items _General file directory,_ and _User-specific file directory_.![Override default file directories](../.gitbook/assets/jabref-lib-properties.png)
+2. **Library → Library properties**, items _Library-specific file directory,_ and _User-specific file directory_.![Override default file directories](../.gitbook/assets/jabref-lib-properties.png)
 
 One of these settings is required. Mostly the "Main file directory" is enough.
 
-JabRef uses these 3 directories to search for the files: JabRef starts in the user-specific file directory, then the general file directory, and, finally, the main file directory​
+JabRef uses these 3 directories to search for the files: JabRef starts in the user-specific file directory, then the library-specific file directory, and, finally, the main file directory​
 
-JabRef enables setting a directory per database. When sharing a library across multiple persons, each user might have a different directory. Either, each user can set his directory in the "Main file directory". In case the group also shares papers and thus there are two directories (the private one and a group-shared one), one can set a directory within the library (the "General file directory"). In case a user has a different location of the shared folder (e.g., different paths on Linux and Windows), he can use the "User-specific file directory". This setting is persisted in the `bib` file in a way that it does not overwrite the setting of another user. For this, JabRef uses the username of the currently logged-in user (`-<loginname>` is used as a suffix in the `jabref-meta` field). So, both `mary` and `aileen` can set a different user-specific file directory.
+JabRef enables setting a directory per database. When sharing a library across multiple persons, each user might have a different directory. Either, each user can set his directory in the "Main file directory". In case the group also shares papers and thus there are two directories (the private one and a group-shared one), one can set a directory within the library (the "Library-specific file directory"). In case a user has a different location of the shared folder (e.g., different paths on Linux and Windows), he can use the "User-specific file directory". This setting is persisted in the `bib` file in a way that it does not overwrite the setting of another user. For this, JabRef uses the username of the currently logged-in user (`-<loginname>` is used as a suffix in the `jabref-meta` field). So, both `mary` and `aileen` can set a different user-specific file directory.
 
-If JabRef saves an attached file and my login name matches the name stored in the `bib` file, it chooses that directory. If no match is found, it uses the "General file directory" of the bib file. If that is not found, it uses the one configured at File → Preferences → Linked files.
+If JabRef saves an attached file and my login name matches the name stored in the `bib` file, it chooses that directory. If no match is found, it uses the "Library-specific file directory" of the bib file. If that is not found, it uses the one configured at File → Preferences → Linked files.
 
-In some settings, the bib file is stored in **the same directory** as the PDF files. Then, one ignores all the above directories and enable "Search and store files relative to library file location". In this case, JabRef starts searching for PDF files in the directory of the `bib` file. It is also possible to achieve this result by setting `.` as "General file directory" in the library properties.
+In some settings, the bib file is stored in **the same directory** as the PDF files. Then, one ignores all the above directories and enable "Search and store files relative to library file location". In this case, JabRef starts searching for PDF files in the directory of the `bib` file. It is also possible to achieve this result by setting `.` as "Library-specific file directory" in the library properties.
 
 ![Search and store files relative to library file location](<../.gitbook/assets/preferences-file-searchandstoreforfilesrelativetolibraryfilelocation.png>).
 
-Relative file directories obviously only work in the library properties for a bib file, e.g. `a.bib` Library → Library properties → General file directory → `papers`. Assume to have two bib files: `a.bib` and `b.bib` located in different directories: `a.bib` located at `C:\a.bib` and `b.bib` located at `X:\b.bib`. When I click on the `+` icon in the general Tab of file `a.bib`, the popup is opened in the directory `C:\papers` (assuming `C:\papers` exists).
+Relative file directories obviously only work in the library properties for a bib file, e.g. `a.bib` Library → Library properties → Library-specific file directory → `papers`. Assume to have two bib files: `a.bib` and `b.bib` located in different directories: `a.bib` located at `C:\a.bib` and `b.bib` located at `X:\b.bib`. When I click on the `+` icon in the general Tab of file `a.bib`, the popup is opened in the directory `C:\papers` (assuming `C:\papers` exists).
 
 ## Auto-linking files
 

--- a/en/setup/databaseproperties.md
+++ b/en/setup/databaseproperties.md
@@ -42,10 +42,10 @@ You can select if your library follows the [BibTeX or the biblatex format](../ci
 
 In your library, files (PDF, etc.) can be linked to an entry. The list of these files are stored in the _file_ field of the entry. The location of these files has to be specified.
 
-For your library, you can define a **General file directory** and a **User-specific file directory**. These settings override the _main file directory_ defined in the Preferences dialog.
+For your library, you can define a **Library-specific file directory** and a **User-specific file directory**. These settings override the _main file directory_ defined in the Preferences dialog.
 
-The **General file directory** is a common path for all the users of a shared database.\
-The **User-specific file directory** allows each user to have its own file directory for the database. If defined, it overrides the **General file directory**.
+The **Library-specific file directory** is a common path for all the users of a shared database.\
+The **User-specific file directory** allows each user to have its own file directory for the database. If defined, it overrides the **Library-specific file directory**.
 
 JabRef stores the name of the current system alongside the **User-specific file directory**. This assumes that each user of the library has a different system name. For example, when using the computer _laptop_, the entry in the bib file is @Comment{jabref-meta: fileDirectory-jabref-laptop:\somedir;}
 


### PR DESCRIPTION
Note: pending approval of PR to jabref code repository: https://github.com/JabRef/jabref/pull/12037

This PR amends the user docs to reflect changes in Jabref's `General File Directory` to `User-Specific File Directory`.

@koppor: the following line has been excluded as it appears to refer to a different functionality. please let me know if my understanding is incorrect:

``` en/setup/databaseproperties.md
{% hint style="info" %}
The legacy PDF/PS links (i.e. the pdf and ps fields, which were used in JabRef versions prior to 2.3), should in current versions be replaced by general file links. This can be done using **Quality → Cleanup entries...** and enabling _Upgrade external PDF/PS links to use the 'file' field_.​
{% endhint %}
```
