### PR TITLE
Switch to linkspector

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -1,38 +1,25 @@
 name: Check links
-
 on:
   push:
     paths:
       - '.github/workflows/check-links.yml'
-      - '.lycheeignore'
-      - 'lychee.toml'
       - '**/*.md'
   pull_request:
   schedule:
-    # Run on the first of each month at 9:00 AM (See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07)
     - cron: "0 9 1 * *"
   workflow_dispatch:
-
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.ref }}"
   cancel-in-progress: true
-
 jobs:
-  lychee:
+  check-links:
+    name: runner / linkspector
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Run linkspector
+        uses: umbrelladocs/action-linkspector@v1
         with:
-          show-progress: 'false'
-      - name: Restore lychee cache
-        uses: actions/cache@v4
-        with:
-          path: .lycheecache
-          key: cache-lychee-${{ github.sha }}
-          restore-keys: cache-lychee-
-      - name: Link Checker
-        id: lychee
-        uses: lycheeverse/lychee-action@v2.0.2
-        with:
-          fail: true
-          args: --accept '200,201,202,203,204,403,429,500' --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          fail_level: any

--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -1,0 +1,5 @@
+dirs:
+  - .
+useGitIgnore: true
+ignorePatterns:
+  - pattern: '^https://arxiv\.org/'

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -28,7 +28,7 @@ MD026:
 
 MD033:
   # we have <a> tags with ids
-  allowed_elements: ['a', 'div', 'figure', 'figcaption', 'img', 'p', 'mark']
+  allowed_elements: ['a', 'div', 'figure', 'figcaption', 'img', 'kbd', 'p', 'mark']
 
 # we allow images without alt text
 MD045: false

--- a/en/advanced/commandline.md
+++ b/en/advanced/commandline.md
@@ -47,11 +47,11 @@ The word _true_ prevents the file name from being interpreted as an argument to 
 
 * [Help: `-h`](commandline.md#help--h)
 * [No-GUI mode: `-n`](commandline.md#no-gui-mode--n)
-* [Import file: `-i filename[,import format]`](commandline.md#import-file--i-filenameimport-format/README.md)
+* [Import file: `-i filename[,import format]`](commandline.md#import-file--i-filenameimport-format)
 * [Export file: `-o filename[,export format]`](commandline.md#export-file--o-filenameexport-format)
 * [Import BibTeX: `-importBibtex`](commandline.md#import-bibtex--importbibtex)
 * [Export matching entries: `-m [field]searchTerm,outputFile:file[,exportFormat]`](commandline.md#export-matching-entries--m-fieldsearchtermoutputfilefileexportformat)
-* [Write BibTexEntry as XMP metadata to PDF: `-w CITEKEY1[,CITEKEY2][,CITEKEYn] | PDF1[,PDF2][,PDFn] | all`](commandline.md#write-bibtexentry-as-xmp-metadata-to-pdf--w-citekey1citekey2citekeyn--pdf1pdf2pdfn--all)
+* Write BibTexEntry as XMP metadata to PDF: `-w CITEKEY1[,CITEKEY2][,CITEKEYn] | PDF1[,PDF2][,PDFn] | all`
 * [Fetch entries from Web: `-f=FetcherName:QueryString`](commandline.md#fetch-entries-from-web--ffetchernamequerystring)
 * [Subdatabase from .aux file: `-a infile[.aux],outfile[.bib] base-BibTeX-file`](commandline.md#subdatabase-from-aux-file--a-infileauxoutfilebib-base-bibtex-file)
 * [Set file links: `-asfl`](commandline.md#set-file-links--asfl)
@@ -238,4 +238,4 @@ As developer, you pass arguments to the app using gradle's `--app` switch. Enclo
 
 You can then view the event log in JabRef as follows:
 
-<figure><img src="../.gitbook/assets/dev-log (2).png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/dev-log.png" alt=""><figcaption></figcaption></figure>

--- a/en/advanced/custom-themes.md
+++ b/en/advanced/custom-themes.md
@@ -22,11 +22,11 @@ You can find a collection of user contributed themes at [https://themes.jabref.o
 
 ## Examples
 
-**Light Theme** ![Light Theme](<../.gitbook/assets/theme-light (1).png>)
+**Light Theme** ![Light Theme](<../.gitbook/assets/theme-light.png>)
 
-**Dark Theme** ![Dark Theme](<../.gitbook/assets/theme-dark (1).png>)
+**Dark Theme** ![Dark Theme](<../.gitbook/assets/theme-dark.png>)
 
-**Custom Theme** ![Custom Theme](<../.gitbook/assets/theme-custom (1).png>) (based on the Dark Theme)
+**Custom Theme** ![Custom Theme](<../.gitbook/assets/theme-custom.png>) (based on the Dark Theme)
 
 ## Known bugs
 

--- a/en/advanced/externalfiles.md
+++ b/en/advanced/externalfiles.md
@@ -14,10 +14,10 @@ To change the external viewer settings, go to **Options → Preferences → Exte
 
 There are several ways to open an external web page. In the entry editor, click on the icon "open" right of the text field to open the respective DOI or URL.
 
-![Open DOI](<../.gitbook/assets/entryeditor-doi-open (1).png>)
+![Open DOI](<../.gitbook/assets/entryeditor-doi-open.png>)
 
 In the entry table you can select an entry and use the menu choice, keyboard shortcut or the right-click menu to open the file or web page. Finally, you can click on a URL or DOI icon.
 
-![Open DOI via popup](<../.gitbook/assets/entrytable-doi-popup (1).png>)
+![Open DOI via popup](<../.gitbook/assets/entrytable-doi-popup.png>)
 
 By default the entry table will contain a singly column containing an indicator whether there is a DOI or a URL linked. You can remove the "Link identifiers" column in **Options → Preferences → Entry table**.

--- a/en/advanced/journalabbreviations.md
+++ b/en/advanced/journalabbreviations.md
@@ -10,7 +10,7 @@ This feature can be configured under **Options → Preferences → Manage journa
 
 JabRef includes a fairly extensive build-in list of journal abbreviations. This list is a merge of all lists available at [https://abbrv.jabref.org](https://abbrv.jabref.org). However, this might still be incomplete (or outdated) for the purposes of some users. Thus, JabRef allows to add abbreviations in the form of a personal list or external lists.
 
-![General view](<../.gitbook/assets/JournalAbbreviations (6).png>)
+![General view](<../.gitbook/assets/JournalAbbreviations.png>)
 
 ## Using the feature
 
@@ -43,7 +43,7 @@ Once you click _Save changes_, if you have selected a file, and the table contai
 
 You can link to a number of external lists. These links can be set up on top of the **Manage journal abbreviations** window. External lists are similar to the personal list. The _Open existing list_ button allows you to select an existing file on your computer.
 
-![External list](<../.gitbook/assets/JournalAbbreviations-ExternalList (6).png>)
+![External list](<../.gitbook/assets/JournalAbbreviations-ExternalList.png>)
 
 External lists can be found at [JabRef's repository abbreviation lists](http://abbrv.jabref.org). These data files are in CSV format (using comma as separators):
 

--- a/en/cite/pushtoapplications.md
+++ b/en/cite/pushtoapplications.md
@@ -14,7 +14,7 @@ To push as citation, first select the entries in your entry table that you would
 * Press `CTRL + L`
 * Click on the dedicated button in the taskbar (left of the _Generate citation key_ button)
 
-![](<../.gitbook/assets/push-external-button-windows (5).png>)
+![](<../.gitbook/assets/push-external-button-windows.png>)
 
 By default the external editor used to push citations is TeXstudio. You can select another application in **Options → Preferences → External programs**. Under the **Push applications** section, click on the **Application to push entries to** field. This will cause a dropdown menu to appear, from which you are then able to select from a list of all the external editors you have configured.
 
@@ -24,15 +24,15 @@ You can configure the citation command at "Cite command". JabRef intelligently p
 
 Once you have made your selection and click **Save**, the push-to-external application button icon will change to match that of the selected external editor application.
 
-![New Application After Select](<../.gitbook/assets/after-application-selection (6).png>)
+![New Application After Select](<../.gitbook/assets/after-application-selection.png>)
 
 When you click on the push-to-external application button, JabRef will export your selected entries to an open LaTeX file in the selected external editor application. As an example, here is what happens when you export one entry to TexStudio.
 
-![Initial Push to External Export](<../.gitbook/assets/initial-push-export (5).png>)
+![Initial Push to External Export](<../.gitbook/assets/initial-push-export.png>)
 
 As long as you continue using the same external editor application, clicking on the push-to-external application button for subsequent exports will just add new citations or extend an existing citation with additional entries. Following the example above, here is what happens when you export a second entry to TeXStudio on an existing citation, which is extended to include the new entry in your LaTeX document.
 
-![Subsequent Push to External Export](<../.gitbook/assets/subsequent-push-export (5).png>)
+![Subsequent Push to External Export](<../.gitbook/assets/subsequent-push-export.png>)
 
 ## Hints on Emacs
 

--- a/en/collaborative-work/export/customexports.md
+++ b/en/collaborative-work/export/customexports.md
@@ -74,11 +74,11 @@ A conditional block can also be dependent on more than one field, and the conten
 * OR operator : `|`, `||`
 * NOT operator : `!`
 
-For example, to output text only if both `year` and `month` are set, use a block like the following: `\begin{year&&month}Month: \format[HTMLChars]{\month}\end{year&&month}`  
+For example, to output text only if both `year` and `month` are set, use a block like the following: `\begin{year&&month}Month: \format[HTMLChars]{\month}\end{year&&month}`
 which will print "Month: " plus the contents of the `month` field, but only if also the `year` field is defined.
 
-As an example for the usage of the NOT operator, consider the following:  
-`\begin{!year}\format[HTMLChars]{(no year)}\end{!year}`  
+As an example for the usage of the NOT operator, consider the following:
+`\begin{!year}\format[HTMLChars]{(no year)}\end{!year}`
 Here, "no year" is printed as output text if no year field is defined.
 
 **Note:** Use of the `\begin` and `\end` commands is a key to creating layout files that work well with a variety of entry types.
@@ -126,7 +126,7 @@ JabRef provides the following set of formatters:
 * `RemoveBrackets` : removes all curly brackets "{" or "}".
 * `RemoveBracketsAddComma` : removes all curly brackets "{" or "}". The closing curly bracket is replaced by a comma.
 * `RemoveLatexCommands` : removes LaTeX commands like `\em`, `\textbf`, etc. If used together with `HTMLChars` or `XMLChars`, this formatter should be called last.
-* `RemoveTilde` : replaces the tilde character used in LaTeX as a non-breakable space by a regular space. Useful in combination with the [NameFormatter](customexports.md#NameFormatter) discussed in the next section.
+* `RemoveTilde` : replaces the tilde character used in LaTeX as a non-breakable space by a regular space. Useful in combination with the `Authors` formatter discussed in the next section.
 * `RemoveWhitespace` : removes all whitespace characters.
 * `Replace(regexp,replacewith)` : does a regular expression replacement. To use this formatter, a two-part argument must be given. The parts are separated by a comma. To indicate the comma character, use an escape sequence: \,
 
@@ -149,14 +149,14 @@ JabRef provides the following set of formatters:
 
 To accommodate for the numerous citation styles, the `Authors` formatter allows flexible control over the layout of the author list. The formatter takes a comma-separated list of options, by which the default values can be overridden. The following option/value pairs are currently available, where the default values are given in curly brackets.
 
-`AuthorSort = [ {FirstFirst} | LastFirst | LastFirstFirstFirst ]`  
+`AuthorSort = [ {FirstFirst} | LastFirst | LastFirstFirstFirst ]`
 specifies the order in which the author names are formatted.
 
 * `FirstFirst` : first names are followed by the surname.
 * `LastFirst` : the authors' surnames are followed by their first names, separated by a comma.
 * `LastFirstFirstFirst` : the first author is formatted as LastFirst, the subsequent authors as FirstFirst.
 
-`AuthorAbbr = [ FullName | LastName | {Initials} | InitialsNoSpace | FirstInitial | MiddleInitial ]`  
+`AuthorAbbr = [ FullName | LastName | {Initials} | InitialsNoSpace | FirstInitial | MiddleInitial ]`
 specifies how the author names are abbreviated.
 
 * `FullName` : shows full author names; first names are not abbreviated.
@@ -166,7 +166,7 @@ specifies how the author names are abbreviated.
 * `FirstInitial` : only first initial is shown.
 * `MiddleInitial` : first name is shown, but all middle names are abbreviated.
 
-`AuthorPunc = [ {FullPunc} | NoPunc | NoComma | NoPeriod ]`  
+`AuthorPunc = [ {FullPunc} | NoPunc | NoComma | NoPeriod ]`
 specifies the punctuation used in the author list when `AuthorAbbr` is used
 
 * `FullPunc` : no changes are made to punctuation.
@@ -174,19 +174,19 @@ specifies the punctuation used in the author list when `AuthorAbbr` is used
 * `NoComma` : all commas are removed from the author name.
 * `NoPeriod` : all full stops are removed from the author name.
 
-`AuthorSep = [ {Comma} | And | Colon | Semicolon | Sep=<string> ]`  
+`AuthorSep = [ {Comma} | And | Colon | Semicolon | Sep=<string> ]`
 specifies the separator to be used between authors. Any separator can be specified, with the `Sep=<string>` option. Note that appropriate spaces need to be added around `string`.
 
-`AuthorLastSep = [ Comma | {And} | Colon | Semicolon | Amp | Oxford | LastSep=<string> ]`  
+`AuthorLastSep = [ Comma | {And} | Colon | Semicolon | Amp | Oxford | LastSep=<string> ]`
 specifies the last separator in the author list. Any separator can be specified, with the `LastSep=<string>` option. Note that appropriate spaces need to be added around `string`.
 
-`AuthorNumber = [ {inf} | <integer> ]`  
+`AuthorNumber = [ {inf} | <integer> ]`
 specifies the number of authors that are printed. If the number of authors exceeds the maximum specified, the authorlist is replaced by the first author \(or any number specified by `AuthorNumberEtAl`\), followed by `EtAlString`.
 
-`AuthorNumberEtAl = [ {1} | <integer> ]`  
+`AuthorNumberEtAl = [ {1} | <integer> ]`
 specifies the number of authors that are printed if the total number of authors exceeds `AuthorNumber`. This argument can only be given after `AuthorNumber` has already been given.
 
-`EtAlString = [ { et al.} | EtAl=<string> ]`  
+`EtAlString = [ { et al.} | EtAl=<string> ]`
 specifies the string used to replace multiple authors. Any string can be given, using `EtAl=<string>`
 
 If an option is unspecified, the default value \(shown in curly brackets above\) is used. Therefore, only layout options that differ from the defaults need to be specified. The order in which the options are defined is \(mostly\) irrelevant. So, for example,
@@ -203,16 +203,16 @@ As mentioned, the order in which the options are specified is irrelevant. There 
 
 Given the following authors, _"Joe James Doe and Mary Jane and Bruce Bar and Arthur Kay"_ ,the `Authors` formatter will give the following results:
 
-`Authors()`, or equivalently, `Authors(FirstFirst,Initials,FullPunc,Comma,And,inf,EtAl= et al.)`  
+`Authors()`, or equivalently, `Authors(FirstFirst,Initials,FullPunc,Comma,And,inf,EtAl= et al.)`
 J. J. Doe, M. Jane, B. Bar and A. Kay
 
-`Authors(LastFirstFirstFirst,MiddleInitial,Semicolon)`  
+`Authors(LastFirstFirstFirst,MiddleInitial,Semicolon)`
 Doe, Joe J.; Mary Jane; Bruce Bar and Arthur Kay
 
-`Authors(LastFirst,InitialsNoSpace,NoPunc,Oxford)`  
+`Authors(LastFirst,InitialsNoSpace,NoPunc,Oxford)`
 Doe JJ, Jane M, Bar B, and Kay A
 
-`Authors(2,EtAl= and others)`  
+`Authors(2,EtAl= and others)`
 J. J. Doe and others
 
 Most commonly available citation formats should be possible with this formatter. For even more advanced options, consider using the Custom Formatters detailed below.

--- a/en/collaborative-work/sqldatabase/README.md
+++ b/en/collaborative-work/sqldatabase/README.md
@@ -10,25 +10,25 @@ To use this feature you have to connect to a remote database. To do so you have 
 
 ### SSL configuration
 
-Since version 5.0 JabRef supports secure SSL connection to the database. For PostgreSQL make sure the server supports SSL and you have correctly setup the [certificates](https://www.postgresql.org/docs/current/static/ssl-tcp.html). Then [convert the client certificates](https://jdbc.postgresql.org/documentation/ssl/#configuring-the-client) into a java readable format and import them into a (custom) keystore. For MySQL the procedure is similar. [Setting up MySQL with SSL](https://dev.mysql.com/doc/refman/8.0/en/using-encrypted-connections.html) and [converting the certificates](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-using-ssl.html) for the java keystore. However, it has only been tested with PostgreSQL. Once the certificates are imported into the keystore, specify the path to the keystore file in the connection dialog and the password for accessing the keystore.
+Since version 5.0 JabRef supports secure SSL connection to the database. For PostgreSQL make sure the server supports SSL and you have correctly setup the [certificates](https://www.postgresql.org/docs/current/static/ssl-tcp.html). Then [convert the client certificates](https://jdbc.postgresql.org/documentation/ssl/#configuring-the-client) into a java readable format and import them into a (custom) keystore. For MySQL the procedure is similar. [Setting up MySQL with SSL](https://dev.mysql.com/doc/refman/8.0/en/using-encrypted-connections.html) and converting the certificates for the java keystore. However, it has only been tested with PostgreSQL. Once the certificates are imported into the keystore, specify the path to the keystore file in the connection dialog and the password for accessing the keystore.
 
-![Screenshot of Connect to shared database dialog](<../../.gitbook/assets/open-shared-database-dialog (1).png>)
+![Screenshot of Connect to shared database dialog](<../../.gitbook/assets/open-shared-database-dialog.png>)
 
 After connecting to your shared database, your main window should look like this:
 
-![Screenshot of JabRef with an open shared database](<../../.gitbook/assets/open-shared-databse-screenshot (1).png>)
+![Screenshot of JabRef with an open shared database](<../../.gitbook/assets/open-shared-databse-screenshot.png>)
 
 JabRef will automatically detect your changes and push them to the shared side. JabRef will also constantly check if there is a newer version available. If you experience connection issues, you can pull changes from your shared database via the icon in the icon bar. If a newer version is available, JabRef will try to automatically merge the new version and your local copy. If this fails, the **Update refused** dialog will show up. You will then have to manually merge using the **Update refused** dialog. The dialog helps you by pointing out the differences, you then will have to choose if you want to keep your local version or update to the shared version. Confirm your merge by clicking on **Merge entries**.
 
-![Screenshot of Update refused dialog](<../../.gitbook/assets/update-refused-merge-dialog (1).png>)
+![Screenshot of Update refused dialog](<../../.gitbook/assets/update-refused-merge-dialog.png>)
 
 The **Update refused** dialog can also take a different form, if the BibEntry you currently work on has been deleted on the shared side. You can choose to keep the BibEntry in the database by clicking **Keep** or update to the shared side and click **Close**.
 
-![Screenshot of Update refused dialog due to a deleted entry](<../../.gitbook/assets/update-refused-deleted-entry-dialog (1).png>)
+![Screenshot of Update refused dialog due to a deleted entry](<../../.gitbook/assets/update-refused-deleted-entry-dialog.png>)
 
 If you experience a problem with your connection to your shared database, the **Connection lost** dialog will show up. You can choose to **Reconnect**, **Work offline** or **Close database**. Most of the time simply reconnecting will fix this problem, if that's not the case you will have to choose between **Work offline** or **Close database**. Pick **Work offline** if you want to make sure your changes are saved. If you think there is nothing to save just pick **Close database**. If you choose to work offline, JabRef will convert the shared database to a local .bib database. Since you are no longer working online, but instead on a local database, you will have to import your work via copy and paste into the shared database. However before you import it into the shared database, make sure to check if changes happened during your offline time. Otherwise you might override someone else's work.
 
-![Screenshot of Connection lost dialog](<../../.gitbook/assets/connection-lost-dialog (1).png>)
+![Screenshot of Connection lost dialog](<../../.gitbook/assets/connection-lost-dialog.png>)
 
 ## Try it out
 

--- a/en/collect/add-entry-manually.md
+++ b/en/collect/add-entry-manually.md
@@ -4,11 +4,11 @@ To add a new entry, select **Library → New entry...**, press `CTRL + N​` or 
 
 A dialog window is displayed. By default, 5 common types of entries are displayed:
 
-![Window for selecting default entry types. Note: the actual content of the "others" menu depends on the database mode (BibTeX or biblatex).](<../.gitbook/assets/jabref-5.3-selectentrytype (1).png>)
+![Window for selecting default entry types. Note: the actual content of the "others" menu depends on the database mode (BibTeX or biblatex).](<../.gitbook/assets/jabref-5.3-selectentrytype.png>)
 
 For other types of entries, click on `Others.` That expands the window and displays the other entry types available:
 
-![Window with all available entry types. Note: the actual content of the "others" menu depends on the database mode (BibTeX or biblatex).](<../.gitbook/assets/jabref-5.3-selectentrytype-expanded (1).png>)
+![Window with all available entry types. Note: the actual content of the "others" menu depends on the database mode (BibTeX or biblatex).](<../.gitbook/assets/jabref-5.3-selectentrytype-expanded.png>)
 
 Finally, the [entry editor](../advanced/entryeditor/) opens and let you fill in the various fields.
 

--- a/en/collect/add-entry-using-an-id.md
+++ b/en/collect/add-entry-using-an-id.md
@@ -8,7 +8,7 @@ description: Create an entry based on an ID such as DOI or ISBN.
 
 For other identifiers, choose **Library → New entry**, or click on the `New entry` button, or use the keyboard shortcut `CTRL + N`. In the lower part of the window, there are two boxes : "ID type" and "ID". In the field "ID type", you can select the desired identifier, e.g. "ISBN" (it works also for DOI). Then enter the identifier in the textbox below and press Enter. That will generate an entry based on the given ID (you can also click on "Generate"). The entry is added to your library and opened in the entry editor. In case an error occurs, a popup is shown.
 
-![Window for selecting an entry type or the ID of an entry. Note: the actual content of the dialog depends on the database mode (BibTeX or biblatex).](<../.gitbook/assets/jabref-5.3-selectentrytype (1).png>)
+![Window for selecting an entry type or the ID of an entry. Note: the actual content of the dialog depends on the database mode (BibTeX or biblatex).](<../.gitbook/assets/jabref-5.3-selectentrytype.png>)
 
 {% hint style="info" %}
 Sometimes the new entry contains a `url` field. This field usually points to the URL of the book at the respective online book store. In case you buy the book using this link, the service provider (e.g., [ebook.de](https://www.ebook.de)) receive a commission to fund the service.
@@ -38,7 +38,7 @@ First, [eBook.de's](https://www.ebook.de/de/) API is used to fetch bibliographic
 
 ID search is carried out using the [International Standard Book Number](https://en.wikipedia.org/wiki/International_Standard_Book_Number).
 
-![Screenshot of new entry dialog](<../.gitbook/assets/newentrychoosetype-idgeneratorhighlighted-isbn (8).png>)
+![Screenshot of new entry dialog](<../.gitbook/assets/newentrychoosetype-idgeneratorhighlighted-isbn.png>)
 
 ### DiVA
 
@@ -46,7 +46,7 @@ ID search is carried out using the [International Standard Book Number](https://
 
 ID search is carried out using the DiVA id (diva2).
 
-![Screenshot of new entry dialog](<../.gitbook/assets/newentrychoosetype-idgeneratorhighlighted-diva (1).png>)
+![Screenshot of new entry dialog](<../.gitbook/assets/newentrychoosetype-idgeneratorhighlighted-diva.png>)
 
 ### DOI
 
@@ -54,7 +54,7 @@ JabRef uses [http://dx.doi.org/](http://dx.doi.org) (provided by [http://crossre
 
 ID search is carried out using the DOI.
 
-![Screenshot of new entry dialog](<../.gitbook/assets/newentrychoosetype-idgeneratorhighlighted (1).png>)
+![Screenshot of new entry dialog](<../.gitbook/assets/newentrychoosetype-idgeneratorhighlighted.png>)
 
 {% hint style="warning" %}
 If JabRef cannot find the reference of your DOI using this ID type, please, try the same DOI with the ID type "mEDRA". The ID type mEDRA looks for the reference corresponding to a DOI too, but using another registration agency.
@@ -98,7 +98,7 @@ ID search is carried out using the DOI.
 
 ID search is carried out using the [ADS Bibcode](http://adsabs.github.io/help/actions/bibcode).
 
-![Screenshot of new entry dialog](<../.gitbook/assets/newentrychoosetype-idgeneratorhighlighted-ads (1).png>)
+![Screenshot of new entry dialog](<../.gitbook/assets/newentrychoosetype-idgeneratorhighlighted-ads.png>)
 
 ### Title
 
@@ -112,7 +112,7 @@ IETF (Internet Engineering Task Force) Datatracker is a database that "contains 
 
 ID search is carried out using the (Request for Comments number) (RFC) of the IETF database.
 
-![Screenshot of new entry dialog](<../.gitbook/assets/newentrychoosetype-idgeneratorhighlighted-rfc (1).png>)
+![Screenshot of new entry dialog](<../.gitbook/assets/newentrychoosetype-idgeneratorhighlighted-rfc.png>)
 
 ### zbMATH Open
 

--- a/en/collect/findunlinkedfiles.md
+++ b/en/collect/findunlinkedfiles.md
@@ -14,9 +14,9 @@ If you drop a PDF onto an entry in the main table or the entry preview in the en
 
 ### Better filenames
 
-JabRef changes the filenames automatically. You can adapt the pattern at Preferences -> Import ![Preferences - Import](<../.gitbook/assets/preferences-import (4).png>)
+JabRef changes the filenames automatically. You can adapt the pattern at Preferences -> Import ![Preferences - Import](<../.gitbook/assets/preferences-import.png>)
 
-Select "Choose pattern" and choose "bibtexkey - title" ![Preferences - Import - Choose pattern](<../.gitbook/assets/preferences-import-choose-pattern (5).png>). This results in the setting `\bibtexkey\begin{title} - \format[RemoveBrackets]{\title}\end{title}`.
+Select "Choose pattern" and choose "bibtexkey - title" ![Preferences - Import - Choose pattern](<../.gitbook/assets/preferences-import-choose-pattern.png>). This results in the setting `\bibtexkey\begin{title} - \format[RemoveBrackets]{\title}\end{title}`.
 
 This makes the filenames start with the citation key followed by the full title. In the concrete case, `\bibtexkey` only may be the better option as the described bibtey key already contains the title.
 
@@ -35,31 +35,31 @@ JabRef offers a BibTeX key generation and offers different patterns described at
 ### Using the Wizard "Search for unlinked local files"
 
 {% hint style="warning" %}
-This information is partially outdated. Please help to improve it ([how to edit a help page](../contributing/how-to-improve-the-help-page.md#editing-help-pages-directly-in-the-browser.md)).
+This information is partially outdated. Please help to improve it ([how to edit a help page](../contributing/how-to-improve-the-help-page.md#editing-help-pages-directly-in-the-browser)).
 {% endhint %}
 
 1. Create or open a library (AKA a `.bib` file).
 2. Go to **Lookup -> Search for unlinked local files**. (or press `SHIFT + F7`)
 
-    ![FindUnlinkedFiles - Menu](<../.gitbook/assets/bildschirmfoto-2021-07-05-um-19.19.09 (1).png>) ![FindUnlinkedFiles - Menu](<../.gitbook/assets/findunlinkedfiles-menu-5.2 (6).png>)
+    ![FindUnlinkedFiles - Menu](<../.gitbook/assets/bildschirmfoto-2021-07-05-um-19.19.09.png>) ![FindUnlinkedFiles - Menu](<../.gitbook/assets/findunlinkedfiles-menu-5.2.png>)
 3. The "Search for unlinked local files" dialog opens.
 
-    <img src="../.gitbook/assets/findunlinkedfiles-window-5.2 (6).png" alt="FindUnlinkedFiles - Initial dialog" data-size="original">
+    <img src="../.gitbook/assets/findunlinkedfiles-window-5.2.png" alt="FindUnlinkedFiles - Initial dialog" data-size="original">
 4. Choose a start directory using the "Browse" button.
 5. Click on "Search" / "Scan directory".
 6. In "Select files", the files not yet contained in the library are shown.
 
-    <img src="../.gitbook/assets/findunlinkedfiles-foundfiles-5.2 (6).png" alt="FindUnlinkedFiles - Found files" data-size="original">
+    <img src="../.gitbook/assets/findunlinkedfiles-foundfiles-5.2.png" alt="FindUnlinkedFiles - Found files" data-size="original">
 7. Select the entries you are interested in. Note: the button `Export selected files` allows you to export the list of the selected files (a text file containing on each line one filename with its path)
 8. Click on `Import`.
 
     The windows close and the entry table now contains the newly-imported entries.
-9. The entry editor with the last imported entry is shown ![FindUnlinkedFiles - 08 - entry editor](<../.gitbook/assets/findunlinkedfiles-08-entry-editor (5).png>)
+9. The entry editor with the last imported entry is shown ![FindUnlinkedFiles - 08 - entry editor](<../.gitbook/assets/findunlinkedfiles-08-entry-editor.png>)
 10. You can now save the file and are finished.
-11. Optional: Click on "General" to see the linked file ![FindUnlinkedFiles - 09 - entry editor - General](<../.gitbook/assets/findunlinkedfiles-09-entry-editor-general (5).png>)
-12. Optional: Click on "BibTeX source" to see the BibTeX source ![FindUnlinkedFiles - 10 - entry editor - BibTeX source](<../.gitbook/assets/findunlinkedfiles-10-entry-editor-bibtex-source (1).png>)
-13. Optional: You have to shrink it to see the entry in the entry table, enlarge the JabRef window and use the mouse at the upper border of the entry editor ![FindUnlinkedFiles - 11 - entry editor - shrunk](<../.gitbook/assets/findunlinkedfiles-11-entry-editor-shrunk (1).png>)
-14. Optional: Press Esc to show the entry preview ![FindUnlinkedFiles - 12 - entry preview](<../.gitbook/assets/findunlinkedfiles-12-entry-preview (1).png>)
+11. Optional: Click on "General" to see the linked file ![FindUnlinkedFiles - 09 - entry editor - General](<../.gitbook/assets/findunlinkedfiles-09-entry-editor-general.png>)
+12. Optional: Click on "BibTeX source" to see the BibTeX source ![FindUnlinkedFiles - 10 - entry editor - BibTeX source](<../.gitbook/assets/findunlinkedfiles-10-entry-editor-bibtex-source.png>)
+13. Optional: You have to shrink it to see the entry in the entry table, enlarge the JabRef window and use the mouse at the upper border of the entry editor ![FindUnlinkedFiles - 11 - entry editor - shrunk](<../.gitbook/assets/findunlinkedfiles-11-entry-editor-shrunk.png>)
+14. Optional: Press Esc to show the entry preview ![FindUnlinkedFiles - 12 - entry preview](<../.gitbook/assets/findunlinkedfiles-12-entry-preview.png>)
 
 {% hint style="danger" %}
 The imported entries may need some editing because all the information gathered from the PDF files may not be accurate (see below "PDFs for which it works").

--- a/en/collect/import/importinspectiondialog.md
+++ b/en/collect/import/importinspectiondialog.md
@@ -10,7 +10,7 @@ Entries are first shown in the inspection window. Note that, if this takes too l
 
 Once the entries displayed in the inspection window, none of them have been added to one of your databases yet.
 
-![Screenshot of the inspection window](<../../.gitbook/assets/inspectionwindow (6).png>)
+![Screenshot of the inspection window](<../../.gitbook/assets/inspectionwindow.png>)
 
 By default, all the entries are selected for importation, as shown by the checked boxes in the _Keep_ column. You can select/unselect an entry by clicking on these checkboxes. On the left panel, buttons allow you to **Select all** the entries for importation, or to **Deselect all** the entries.
 

--- a/en/collect/jabref-browser-extension.md
+++ b/en/collect/jabref-browser-extension.md
@@ -22,15 +22,15 @@ While Chrome extensions can work in Edge \(and will install\), JabRef is configu
 
 ## Usage
 
-After the installation, you should be able to import bibliographic references into JabRef directly from your browser. Just visit a publisher site or some other website containing bibliographic information \(for example, [the arXiv](http://arxiv.org/list/gr-qc/pastweek?skip=0&show=25)\) and click the JabRef symbol in the Firefox search bar \(or press Alt+Shift+J\). Once the JabRef browser extension has extracted the references and downloaded the associated PDF's, the import window of JabRef opens.
+After the installation, you should be able to import bibliographic references into JabRef directly from your browser. Just visit a publisher site or some other website containing bibliographic information \(for example, [the arXiv](https://arxiv.org/list/gr-qc/pastweek?skip=0&show=25)\) and click the JabRef symbol in the Firefox search bar \(or press Alt+Shift+J\). Once the JabRef browser extension has extracted the references and downloaded the associated PDF's, the import window of JabRef opens.
 
 You might want to configure JabRef so that new entries are always imported in an already opened instance of JabRef. For this, activate "Listen to remote operation on port" under the "Network" tab of the JabRef Preferences.
 
 ## Troubleshooting
 
-### In case you have Adblock Plus extension and Jabref extension doesn't work
+### In case you have Adblock Plus extension and JabRef extension doesn't work
 
-1\) Go to [zotero.org](https://zotero.org). 2\) Deactivate AdBlock plus extension for the whole domain \(zotero.org\) by clicking on the Adblock plus extension button and sliding the corresponding slider to allow adds on the whole domain. 3\) Close and reopen the browser in order to reload all the extension and their settings. 4\) Verify the functioning of the Jabref extension by visiting a page you know is working to extract its bibliographic data \(for example, [the arXiv](http://arxiv.org/list/gr-qc/pastweek?skip=0&show=5)\) by pressing the extension button or Alt + Shift + J.
+1\) Go to [zotero.org](https://zotero.org). 2\) Deactivate AdBlock plus extension for the whole domain \(zotero.org\) by clicking on the Adblock plus extension button and sliding the corresponding slider to allow adds on the whole domain. 3\) Close and reopen the browser in order to reload all the extension and their settings. 4\) Verify the functioning of the JabRef extension by visiting a page you know is working to extract its bibliographic data \(for example, [the arXiv](https://arxiv.org/list/gr-qc/pastweek?skip=0&show=5)\) by pressing the extension button or <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>J</kbd>.
 
 In case you encounter problems in this procedure refer to issue \#241 on GitHub for further help.
 

--- a/en/collect/newentryfromplaintext.md
+++ b/en/collect/newentryfromplaintext.md
@@ -26,7 +26,7 @@ O. Kopp, A. Armbruster, und O. Zimmermann, "Markdown Architectural Decision Reco
 
 3. Paste the reference text:
 
-    <div align="left"><figure><picture><source srcset="../.gitbook/assets/Bild 3 - paste text - dark mode (2).png" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/new-entry-from-plain-text-step-3 (1).png" alt=""></picture><figcaption></figcaption></figure></div>
+    <div align="left"><figure><picture><source srcset="../.gitbook/assets/Bild 3 - paste text - dark mode.png" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/new-entry-from-plain-text-step-3.png" alt=""></picture><figcaption></figcaption></figure></div>
 
 4. Choose a parser from the drop-down menu.
 

--- a/en/contributing/how-to-improve-the-help-page.md
+++ b/en/contributing/how-to-improve-the-help-page.md
@@ -16,7 +16,7 @@ At the top of each help page, you can find the GitHub icon with "Edit on GitHub"
 
 This leads you to the GitHub page associated with the help page:
 
-![](<../.gitbook/assets/screenshot-edit-pencil (5).png>)
+![](<../.gitbook/assets/screenshot-edit-pencil.png>)
 
 To actually edit the page, click on the pencil icon, as highlighted above.
 
@@ -24,25 +24,25 @@ To actually edit the page, click on the pencil icon, as highlighted above.
 
 The window to edit the page at GitHub looks like this:
 
-![Edit view at GitHub](<../.gitbook/assets/screenshot-edit-page (4).png>)
+![Edit view at GitHub](<../.gitbook/assets/screenshot-edit-page.png>)
 
 Most text can be simply added/edited in this field as plain text. However, you can style your contribution by using [markdown](https://daringfireball.net/projects/markdown/). Markdown is a rather easy way to format text without the need for complex markup, such as with HTML. You can find an introduction to markdown [here](https://daringfireball.net/projects/markdown/) or [here](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
 
 In order to review your changes, click on the "Preview changes" tab:
 
-![Edit view at GitHub](<../.gitbook/assets/screenshot-edit-preview (5).png>)
+![Edit view at GitHub](<../.gitbook/assets/screenshot-edit-preview.png>)
 
 ### 3. Saving the changes
 
 To save the changes, create a so-called "Commit" by scrolling down and pressing the "Propose File Change" button:
 
-![Save changes](<../.gitbook/assets/screenshot-edit-commit (4).png>)
+![Save changes](<../.gitbook/assets/screenshot-edit-commit.png>)
 
 _Please note: The message you provide here will be visible in the history of the help page, so please consider your change and provide a meaningful description of your changes._
 
 As the last step, submit the changes you have made back to the JabRef team:
 
-![Create Pull Request](<../.gitbook/assets/screenshot-edit-pullrequest (5).png>)
+![Create Pull Request](<../.gitbook/assets/screenshot-edit-pullrequest.png>)
 
 Just press the "Create Pull Request" button, and confirm the creation of the request on the next page.
 
@@ -93,3 +93,5 @@ In case GitBook was fixed, with some command line magic, this could be solved:
 2. Repeat for `gif` instead of `png`.
 3. Create a script doing the renaming in all `.md` files: `fd -e md -x bash -c "echo sed -i '\"s/assets\/\([^%]*\)\(.*\).png/assets\/\\1.png/\"' {}" > fix-mds.sh`. Execute in the root repository. You can also do manually in VSCode using `( \(\d\))+.png` as RegEx.
 4. Repeat for `gif` instead of `png`.
+
+On Ubuntu, use `fdfind` (and install it using `sudo apt install fd-find`).

--- a/en/contributing/how-to-translate-the-ui.md
+++ b/en/contributing/how-to-translate-the-ui.md
@@ -15,12 +15,12 @@ We use the service of [Crowdin](https://translate.jabref.org) to keep our transl
 * Visit [https://translate.jabref.org/](https://translate.jabref.org) to get started
 * Select your preferred language, login, and click on _JabRef\_en.properties_
 
-    <img src="../.gitbook/assets/crowdin-select-file (4).png" alt="Screenshot of Crowdin select file page" data-size="original">
+    <img src="../.gitbook/assets/crowdin-select-file.png" alt="Screenshot of Crowdin select file page" data-size="original">
 * Choose the string you want to translate in the left panel (strings to be translated are listed first)
 
     and enter the translation in the central panel (suggestions are given at the bottom)
 
-    <img src="../.gitbook/assets/crowdin-translate (2).png" alt="Screenshot of Crowdin translation page" data-size="original">
+    <img src="../.gitbook/assets/crowdin-translate.png" alt="Screenshot of Crowdin translation page" data-size="original">
 
 ## Translating JabRef into a new language
 
@@ -34,7 +34,7 @@ To test directly your translation, you must be able to compile the source tree a
 
 Crowdin allows for downloading the current translation file:
 
-![Screenshot of Crowdin download dialog](<../.gitbook/assets/crowdin-download-translation (5).png>)
+![Screenshot of Crowdin download dialog](<../.gitbook/assets/crowdin-download-translation.png>)
 
 Place the downloaded file in the path `src/main/resources/l10n`. Then, execute `gradlew run` in the root directory and JabRef should start.
 

--- a/en/finding-sorting-and-cleaning-entries/checkintegrity.md
+++ b/en/finding-sorting-and-cleaning-entries/checkintegrity.md
@@ -4,4 +4,4 @@ JabRef can check the integrity of a library.
 
 This feature is available through **Quality → Check integrity**.
 
-![Check integrity dialog](<../.gitbook/assets/checkintegrity (1).png>)
+![Check integrity dialog](<../.gitbook/assets/checkintegrity.png>)

--- a/en/finding-sorting-and-cleaning-entries/filelinks.md
+++ b/en/finding-sorting-and-cleaning-entries/filelinks.md
@@ -10,7 +10,7 @@ In BibTeX/biblatex terms, the file links are stored as text in the field `file`.
 
 If the "file" field is included in [General fields](../setup/generalfields.md), you can edit the list of external links for an entry in the [Entry editor](../advanced/entryeditor/). The editor includes buttons for inserting, editing and removing links, as well as buttons for reordering the list of links.
 
-![](<../.gitbook/assets/jabref-entryeditor-files (1).png>)
+![](<../.gitbook/assets/jabref-entryeditor-files.png>)
 
 ## Directories for files
 
@@ -18,9 +18,9 @@ JabRef offers the following directory settings:
 
 1. **File → Preferences → Linked files**, item _Main file directory._
 
-    <img src="../.gitbook/assets/preferences-linkedfiles-5.2 (2).png" alt="Main file directory" data-size="original">
+    <img src="../.gitbook/assets/preferences-linkedfiles-5.2.png" alt="Main file directory" data-size="original">
 
-2. **Library → Library properties**, items _Library-specific file directory,_ and _User-specific file directory_.![Override default file directories](<../.gitbook/assets/jabref-lib-properties (1).png>)
+2. **Library → Library properties**, items _Library-specific file directory,_ and _User-specific file directory_.![Override default file directories](<../.gitbook/assets/jabref-lib-properties.png>)
 
 One of these settings is required. Mostly the "Main file directory" is enough.
 
@@ -32,7 +32,7 @@ If JabRef saves an attached file and my login name matches the name stored in th
 
 In some settings, the bib file is stored in **the same directory** as the PDF files. Then, one ignores all the above directories and enable "Search and store files relative to library file location". In this case, JabRef starts searching for PDF files in the directory of the `bib` file. It is also possible to achieve this result by setting `.` as "Library-specific file directory" in the library properties.
 
-![Search and store files relative to library file location](<../.gitbook/assets/preferences-file-searchandstoreforfilesrelativetolibraryfilelocation (6).png>).
+![Search and store files relative to library file location](<../.gitbook/assets/preferences-file-searchandstoreforfilesrelativetolibraryfilelocation.png>).
 
 Relative file directories obviously only work in the library properties for a bib file, e.g. `a.bib` Library → Library properties → Library-specific file directory → `papers`. Assume to have two bib files: `a.bib` and `b.bib` located in different directories: `a.bib` located at `C:\a.bib` and `b.bib` located at `X:\b.bib`. When I click on the `+` icon in the general Tab of file `a.bib`, the popup is opened in the directory `C:\papers` (assuming `C:\papers` exists).
 
@@ -42,7 +42,7 @@ If you have a file within or below one of your file directories with an extensio
 
 The rules for which file names can be auto-linked to a citation key can be set up in **File → Preferences → Linked files**, section _Autolink files_.
 
-![Linked FIles Preferences](<../.gitbook/assets/preferences-linkedfiles-5.2 (2).png>)
+![Linked FIles Preferences](<../.gitbook/assets/preferences-linkedfiles-5.2.png>)
 
 ## Filename format and file directory pattern
 
@@ -57,7 +57,7 @@ _Explanation_: The expression in the brackets says: Create a subdirectory based 
 
 For an entry, if you want to download a file and link it to the entry, you can do this by clicking the **Download** button in the entry editor.
 
-![Download from URL](<../.gitbook/assets/entryeditor-general-downloadfilefromurl (5).png>)
+![Download from URL](<../.gitbook/assets/entryeditor-general-downloadfilefromurl.png>)
 
 A dialog box will appear, prompting you to enter the URL. The file will be downloaded to your main file directory, named based on the entry's citation key, and finally linked from the entry.
 
@@ -67,7 +67,7 @@ It is possible to have greater flexibility in the naming scheme by using regular
 
 If you open the preferences (**File → Preferences → Linked Files**), you will find in the section _Autolink files_ an option called "Use regular expression search". Checking this option will allow you to enter your own regular expression for search in the PDF directories.
 
-![The linked files preferences](<../.gitbook/assets/preferences-linkedfiles-5.2 (2).png>)
+![The linked files preferences](<../.gitbook/assets/preferences-linkedfiles-5.2.png>)
 
 The following syntax is understood:
 

--- a/en/finding-sorting-and-cleaning-entries/getbibtexdatafromdoi.md
+++ b/en/finding-sorting-and-cleaning-entries/getbibtexdatafromdoi.md
@@ -17,7 +17,7 @@ _The following features require your entry to have a DOI or ISBN and are disable
 * Option A) In the entry table, right-click on the entry to complement, and select the menu **Get bibliographic data from DOI/ISBN/...**
 * Option B) Open the [entry editor](../advanced/entryeditor/), and in the General tab, click on the button **Get bibliographic data from DOI**
 
-![](<../.gitbook/assets/getdoi-entryeditor-jabref5.2 (5).png>)
+![](<../.gitbook/assets/getdoi-entryeditor-jabref5.2.png>)
 
 Using any of the options opens the window _Merge entries_:
 

--- a/en/finding-sorting-and-cleaning-entries/groups.md
+++ b/en/finding-sorting-and-cleaning-entries/groups.md
@@ -63,7 +63,7 @@ A description of the group, to help you remember what it is about. This descript
 
 An icon can be displayed in front of the group name. Choose your favorite icon among the ones available at [https://materialdesignicons.com/](https://materialdesignicons.com), and enter its name of the field _Icon_ (replacing any hyphens (`-`) with underscores (`_`)). The color of the icon can be set in the field _Color_.
 
-![](<../.gitbook/assets/groups-groupwindow-iconcolorhierarchy-jabref5.2 (1).png>)
+![](<../.gitbook/assets/groups-groupwindow-iconcolorhierarchy-jabref5.2.png>)
 
 ### Hierarchical context
 
@@ -112,7 +112,7 @@ JabRef has five types of groups:
 
 Groups based on explicit selection are populated only by manual assignment of entries.
 
-![Fields for collecting by using an explicit selection](<../.gitbook/assets/groups-groupwindow-typeexplicit-jabref5.2 (1).png>)
+![Fields for collecting by using an explicit selection](<../.gitbook/assets/groups-groupwindow-typeexplicit-jabref5.2.png>)
 
 After creating an explicit-selection group, you select the entries to be assigned to it and use either drag-and-drop or the context menu **Add selected entries to this group** of the group interface.
 
@@ -126,7 +126,7 @@ This method of grouping requires that all entries have a unique citation key. In
 
 This method groups entries in which a specified _field_ (e.g. _author_) contains a specified _keyword_ (e.g. _Smith_). The mentioned example will group all entries referring to the author _Smith_.
 
-![Fields for collecting by searching for a keyword](<../.gitbook/assets/groups-groupwindow-typekeyboard-jabref5.2 (1).png>)
+![Fields for collecting by searching for a keyword](<../.gitbook/assets/groups-groupwindow-typekeyboard-jabref5.2.png>)
 
 The search can be case-sensitive or not (checkbox 'Case sensitive'). The search can either be done as a plain-text or a regular-expression search (checkbox 'Regular expression').
 
@@ -136,9 +136,9 @@ The content of the group is updated dynamically whenever the database changes: J
 
 #### Using a free-form search expression
 
-This is similar to the above, but rather than search for a single search term on a single field, a [search expression syntax](search.md#advanced) can be used. It supports logical operators (`AND`, `OR`, `NOT`) and allows searching multiple fields.
+This is similar to the above, but rather than search for a single search term on a single field, a [search expression syntax](search.md) can be used. It supports logical operators (`AND`, `OR`, `NOT`) and allows searching multiple fields.
 
-![Fields for collecting by a free-form search expression](<../.gitbook/assets/groups-groupwindow-typefreeexpression-jabref5.2 (1).png>)
+![Fields for collecting by a free-form search expression](<../.gitbook/assets/groups-groupwindow-typefreeexpression-jabref5.2.png>)
 
 For example, the search expression `keywords=regression and not keywords=linear` groups entries concerned with non-linear regression.
 
@@ -150,7 +150,7 @@ With the group type "Specified keywords", you can quickly create a set of groups
 
 You can also specify characters to ignore, for instance, commas used between keywords. These will be treated as separators between words, and not part of them. This step is important for combined keywords such as `laplace distribution` to be recognized as a single semantic unit. (You cannot use this option to remove complete words. Instead, delete the unwanted groups manually after they were created automatically.)
 
-![Fields for collecting by specified keywords](<../.gitbook/assets/groups-groupwindow-typespecifiedkeywords-jabref5.2 (1).png>)
+![Fields for collecting by specified keywords](<../.gitbook/assets/groups-groupwindow-typespecifiedkeywords-jabref5.2.png>)
 
 The content of the group is updated dynamically whenever the database changes.
 
@@ -158,7 +158,7 @@ The content of the group is updated dynamically whenever the database changes.
 
 The group contains the entries cited in a LaTeX document, based on its '.aux' file. The .aux file has to be specified.
 
-![Fields for collecting by cited entries](<../.gitbook/assets/groups-groupwindow-typecited-jabref5.2 (1).png>)
+![Fields for collecting by cited entries](<../.gitbook/assets/groups-groupwindow-typecited-jabref5.2.png>)
 
 The content of the group is updated dynamically whenever the `.aux` file changes.
 
@@ -166,7 +166,7 @@ The content of the group is updated dynamically whenever the `.aux` file changes
 
 To see easily to which groups an entry belongs to, the entry table has a column dedicated to groups. For each entry, a set of color bars is displayed. The number of bars and their colors depend on the groups to which the entry belongs to.
 
-![](<../.gitbook/assets/groups-groupcolorlabel-jabref5.2 (2).png>)
+![](<../.gitbook/assets/groups-groupcolorlabel-jabref5.2.png>)
 
 By hovering the mouse on this column, you can see the list of groups to which an entry belongs to.
 
@@ -179,13 +179,13 @@ The "groups" column is displayed by default. Using the menu **File → Preferenc
 
 ## Groups and searching
 
-When viewing the contents of selected group(s), a search can be performed within these contents using the [regular search facility](search.md#regular-expressions).
+When viewing the contents of selected group(s), a search can be performed within these contents using the [regular search facility](search.md).
 
 ## Preferences about groups
 
 General preferences for groups can be accessed using **File → Preferences**, tab **Groups**.
 
-![Preferences for tab Groups](<../.gitbook/assets/groups-preferences-jabref5.2 (1).png>)
+![Preferences for tab Groups](<../.gitbook/assets/groups-preferences-jabref5.2.png>)
 
 ### View
 

--- a/en/finding-sorting-and-cleaning-entries/keywords.md
+++ b/en/finding-sorting-and-cleaning-entries/keywords.md
@@ -22,7 +22,7 @@ Additionally, the [special field](specialfields.md) values (relevance, priority,
 
 Select at least one entry and go to **Edit → Manage keywords**.
 
-![](<../.gitbook/assets/keywords-managekeywords-jabref5.2 (1).png>)
+![](<../.gitbook/assets/keywords-managekeywords-jabref5.2.png>)
 
 The keyword list is displayed in two modes:
 
@@ -37,7 +37,7 @@ To fasten the addition of often-used keywords, JabRef can store the list of your
 
 Go to **File → Manage content selectors**.
 
-![](<../.gitbook/assets/managecontentselectors-jabref5.2 (1).png>)
+![](<../.gitbook/assets/managecontentselectors-jabref5.2.png>)
 
 First, click on the field name "Keywords". Then, enter the list of your preferred keywords. Now, when you start to type one of your preferred keywords, JabRef will display a list of the matching ones (independently of the auto-completion). For more details, see the help section about [Managing content selectors](../advanced/contentselector.md).
 

--- a/en/finding-sorting-and-cleaning-entries/saveactions.md
+++ b/en/finding-sorting-and-cleaning-entries/saveactions.md
@@ -149,7 +149,7 @@ Shortens lists of persons if there are more than 2 persons to \"et al.\".
 
 ## Save actions as modifiers
 
-The [field formatters listed above](saveactions.md#list-of-actions) can also be used as modifiers in [citation key patterns](../setup/citationkeypatterns.md) using their keys listed below.
+The field formatters listed above can also be used as modifiers in [citation key patterns](../setup/citationkeypatterns.md) using their keys listed below.
 
 | Save action | Key |
 | :--- | :--- |

--- a/en/finding-sorting-and-cleaning-entries/search.md
+++ b/en/finding-sorting-and-cleaning-entries/search.md
@@ -2,7 +2,7 @@
 
 The search bar is located in the icon bar.
 
-![Screenshot of the search bar](<../.gitbook/assets/search-bar-v5.2 (6).png>)
+![Screenshot of the search bar](<../.gitbook/assets/search-bar-v5.2.png>)
 
 To make the cursor jump to the search field, you can:
 
@@ -61,7 +61,7 @@ To search for entries with the title _or_ the keyword "image processing", type: 
 At the right of the search text field, two buttons allow for selecting some settings:
 
 * Regular expressions
-  * Whether the search query uses [regular expressions](search.md#regular-expressions).
+  * Whether the search query uses regular expressions.
 * Case sensitivity
   * Whether the search query is case-sensitive.
 
@@ -109,9 +109,9 @@ This is how the search currently works in the development version.
 | `title = pa*ediatric AND 1.0`  | Off   | No match. Regex is disabled               | "1.0"                                  |
 | `title = pa*ediatric AND 1.0`  | On    | No match. Regex is disabled for this term | Matches "1.0", "1+0" "1/0", "1q0", ... |
 
-## Search using regular expressions <a href="#regular-expressions" id="regular-expressions"></a>
+## Search using regular expressions <a id="regular-expressions"></a>
 
-In order to only search for content within specific fields and/or to include logical operators in the search expression, a special syntax is available in which these can be specified. Both the field specification and the search term support [regular expressions](search.md#regular-expressions).
+In order to only search for content within specific fields and/or to include logical operators in the search expression, a special syntax is available in which these can be specified. Both the field specification and the search term support regular expressions.
 
 Regular expressions (RegEx for short) define a language for representing patterns matching text, for example when searching. There are different types of RegEx languages. JabRef uses regular expressions as defined in Java. For extensive advanced information about Java's RegEx patterns, please have a look at the [Java documentation](https://docs.oracle.com/en/java/javase/16/docs/api/java.base/java/util/regex/Pattern.html) and at the [Java tutorial](https://docs.oracle.com/javase/tutorial/essential/regex/).
 

--- a/en/finding-sorting-and-cleaning-entries/specialfields.md
+++ b/en/finding-sorting-and-cleaning-entries/specialfields.md
@@ -10,7 +10,7 @@ This feature has to be activated in **File → Preferences → Entry Table** by 
 
 The status of each special field can be displayed in the table of entries as dedicated columns.
 
-![Six special fields can be displayed in the table of entries](<../.gitbook/assets/specialfields-6columns-5.2 (10).png>)
+![Six special fields can be displayed in the table of entries](<../.gitbook/assets/specialfields-6columns-5.2.png>)
 
 Like any other field, the special field columns can be turned on and off individually in **File → Preferences → Entry Table.**
 
@@ -26,7 +26,7 @@ You can see the value of a special field by:
 
 An entry can be marked as relevant: a black-and-white star is displayed (in the first column of the image below).
 
-![](<../.gitbook/assets/specialfields-6columns-5.2 (10).png>)
+![](<../.gitbook/assets/specialfields-6columns-5.2.png>)
 
 ### Read status
 
@@ -40,7 +40,7 @@ JabRef offers a rank from one to five yellow stars to rate your papers. By defau
 
 An entry may be marked as quality assured (fourth column in the image below). For example, you can mark the entries for which a thorough check of the field contents has been done.
 
-![](<../.gitbook/assets/specialfields-6columns-5.2 (10).png>)
+![](<../.gitbook/assets/specialfields-6columns-5.2.png>)
 
 ### Priority
 

--- a/en/getting-started.md
+++ b/en/getting-started.md
@@ -20,7 +20,7 @@ Upon the first start of JabRef the main user interface is showing up the main el
 * Icon bar (shortcuts for most frequently used features)
 * Side bar (for groups and web search)
 
-![Screenshot of main window](<.gitbook/assets/getting-started-main-screen (5).png>)
+![Screenshot of main window](<.gitbook/assets/getting-started-main-screen.png>)
 
 ## Creation of a new library
 
@@ -36,7 +36,7 @@ The usage of a text-based file format has some advantages:
 
 To create a new library, just select the "New library" menu item in the "File" menu:
 
-![Creating a new library](<.gitbook/assets/getting-started-new-library (7).png>)
+![Creating a new library](<.gitbook/assets/getting-started-new-library.png>)
 
 The main screen is now showing an empty "entry table" we will now start to fill with some entries.
 
@@ -46,13 +46,13 @@ To add a new entry select the menu bar entry "Library" -> "New entry", click on 
 
 This opens a dialog where you can select the type of reference you want to store. By default all entry types defined by the BibTeX format are available:
 
-![Screenshot of "new entry" dialog](<.gitbook/assets/getting-started-new-entry (5).png>)
+![Screenshot of "new entry" dialog](<.gitbook/assets/getting-started-new-entry.png>)
 
 For our running example we will select "Article".
 
 After clicking on the "Article" button, the dialog closes and the so called "Entry Editor" is opened for the newly created entry:
 
-![Main window now showing the entry editor](<.gitbook/assets/getting-started-entry-editor (7).png>)
+![Main window now showing the entry editor](<.gitbook/assets/getting-started-entry-editor.png>)
 
 The most important information about the references to be added can now be entered in the "Required Fields" tab. "Author", "Title", "Journal", and "Year" should be self-explanatory - however, a "citationkey", might not be familiar to you. Basically, the idea of the "citationkey" is coming from working with BibTeX, where it is necessary to have an unique identifier for each entry. This allows for referencing within a document you might be creating using the stored information in your library. Moreover, also within JabRef this "key" is used for example for cross-references to other related entries or to determine file names for full-text references.
 
@@ -64,7 +64,7 @@ The default key pattern is `[auth][year]`, which means that Author information i
 
 After entering some information, you can see on the right side of the entry editor a preview of the bibliographic data:
 
-![Added information for new entry](<.gitbook/assets/getting-started-filled-entry-editor (6).png>)
+![Added information for new entry](<.gitbook/assets/getting-started-filled-entry-editor.png>)
 
 There are further possibilities to add entries to your library which are described in the section "Collect" of this documentation:
 
@@ -76,7 +76,7 @@ There are further possibilities to add entries to your library which are describ
 
 After creating the basic information the addition of all other bibliographical details is often cumbersome and error-prone. To ease this task, JabRef allows for an automatic completion of the bibliographic information by looking up the data in public databases. To use this feature just click on the "Update with bibliographic information from the web" button in the editor:
 
-![Update information from web](<.gitbook/assets/getting-started-entry-editor-update-from-web (7).png>)
+![Update information from web](<.gitbook/assets/getting-started-entry-editor-update-from-web.png>)
 
 {% hint style="info" %}
 The found information is most accurate if an identifier like a "DOI" or "ISBN" is maintained. If you already know such an unique identifier, this can also be already the starting point to create a new entry without manual entering any information by using the "create from ID" feature in the Create entry dialog. For more information see: [Collect](https://docs.jabref.org/collect) > ["Add entry using an ID"](https://docs.jabref.org/collect/add-entry-using-an-id)
@@ -84,7 +84,7 @@ The found information is most accurate if an identifier like a "DOI" or "ISBN" i
 
 If additional information is found you will be asked in a dialog which information should be taken over:
 
-![Merging the existing and the web information](<.gitbook/assets/getting-started-merge-entries (7).png>)
+![Merging the existing and the web information](<.gitbook/assets/getting-started-merge-entries.png>)
 
 ## Adding a full text document
 
@@ -96,9 +96,9 @@ In order to use the automated feature, it is necessary to set-up a file director
 
 To test the automatic download of full texts you can click on the "Get full-text" icon next to the file field, or choose "Lookup" -> "Search full text documents online" from the menu. As soon as a full-text is found, the file will be stored in the local file directory and linked to the entry:
 
-![Finding a full-text document online](<.gitbook/assets/getting-started-entry-editor-full-text (7).png>)
+![Finding a full-text document online](<.gitbook/assets/getting-started-entry-editor-full-text.png>)
 
-To open the downloaded full text you can click on the "file" icon before the file name - or use the same icon in the entry table: ![Opening the full-text](<.gitbook/assets/getting-started-open-fulltext (7).png>)
+To open the downloaded full text you can click on the "file" icon before the file name - or use the same icon in the entry table: ![Opening the full-text](<.gitbook/assets/getting-started-open-fulltext.png>)
 
 ## Finding more references in the web
 
@@ -106,7 +106,7 @@ If you want to search for other references, it is also possible to directly trig
 
 The search results will be shown in an window where you can select all the search hits to be added to your library.
 
-![Web Search: Trigger and result window](<.gitbook/assets/getting-started-import-from-web (6).png>)
+![Web Search: Trigger and result window](<.gitbook/assets/getting-started-import-from-web.png>)
 
 ## Next steps
 

--- a/en/setup/citationkeypatterns.md
+++ b/en/setup/citationkeypatterns.md
@@ -129,17 +129,17 @@ Formatters are primarily used as [save actions](../finding-sorting-and-cleaning-
 
 ## Regular Expressions (RegEx)
 
-Regular expressions (or RegEx for short) match patterns within a string. In other words, they are a way to search for (or replace) text within a closed off sequence of characters. They can enhance citation key patterns by altering [modifiers](citationkeypatterns.md#modifiers) even further (e.g. via **`:regex("pattern", "replacement")`**). Another use case for them is to [replace existing key patterns](citationkeypatterns.md#replace-regular-expression).
+Regular expressions (or RegEx for short) match patterns within a string. In other words, they are a way to search for (or replace) text within a closed off sequence of characters. They can enhance citation key patterns by altering [modifiers](citationkeypatterns.md#modifiers) even further (e.g. via **`:regex("pattern", "replacement")`**). Another use case for them is to [replace existing key patterns](citationkeypatterns.md#replace-via-regular-expression).
 
-Documentation and examples for RegEx syntax can be found [in the Java documentation](https://docs.oracle.com/javase/9/docs/api/java/util/regex/Pattern.html) and [in the Jabref documentation](../finding-sorting-and-cleaning-entries/search.md#advanced).
+Documentation and examples for RegEx syntax can be found [in the Java documentation](https://docs.oracle.com/javase/9/docs/api/java/util/regex/Pattern.html) and [in the JabRef documentation](../finding-sorting-and-cleaning-entries/search.md#modifiers-for-fields).
 
-Keep in mind, Jabref uses a Java flavored regular expressions engine (there are multiple engines) and therefore treats `\` and some other special meta-characters as escape characters. If you want to include any backslash into your RegEx, you have to use `\\` instead of `\`.
+Keep in mind, JabRef uses a Java flavored regular expressions engine (there are multiple engines) and therefore treats `\` and some other special meta-characters as escape characters. If you want to include any backslash into your RegEx, you have to use `\\` instead of `\`.
 
 ## Replace via Regular Expression
 
 In addition to using regular expression replacement as [modifiers](citationkeypatterns.md#modifiers) of the field markers within [citation key patterns](citationkeypatterns.md#citation-key-patterns), regular expression matching and replacement can be done after the key patterns have been applied. In this case, the regular expression and replacement string are entered in the separate text fields above the [citation key patterns](citationkeypatterns.md#citation-key-patterns) section. If the replacement string is empty, then matches of the regular expression will be removed from the generated key.
 
-![Citation key generator preferences - regex replacement](<../.gitbook/assets/preferences-citation-key-generator-regex-replacement (7).png>)
+![Citation key generator preferences - regex replacement](<../.gitbook/assets/preferences-citation-key-generator-regex-replacement.png>)
 
 The regex `(?<=.{12}+).+` with an empty replacement string will cut the length of all citation keys to 12.
 
@@ -147,7 +147,7 @@ The regex `(?<=.{12}+).+` with an empty replacement string will cut the length o
 
 The citation key generator preferences contain an option for removing unwanted characters. Add or remove characters to the right of "Remove the following characters:" to control which characters are included in the citation keys.
 
-![Citation key generator preferences - unwanted characters](<../.gitbook/assets/preferences-citation-key-generator-remove-characters (7).png>)
+![Citation key generator preferences - unwanted characters](<../.gitbook/assets/preferences-citation-key-generator-remove-characters.png>)
 
 Since JabRef 6.0, the default unwanted characters are `?`, `!`, `;`, `^`, `ʹ`, and backtick (\`). If you also want to have `-` be removed (e.g., "Al-Ketan, 2019" should be "AlK19" instead of "Al-19" when using `[auth3][shortyear]`, add `-` to this list.
 
@@ -169,13 +169,13 @@ To change the citation key pattern to `[authors][camel]` for all libraries witho
 
 1. Open the preferences
 
-    <img src="../.gitbook/assets/optionspreferences%20(10).png" alt="File → Preferences" data-size="original">
+    <img src="../.gitbook/assets/optionspreferences.png" alt="File → Preferences" data-size="original">
 2. Navigate to "Citation key generator"
 
-    <img src="../.gitbook/assets/preferences-citation-key-generator (2).png" alt="Citation key generator preferences" data-size="original">
+    <img src="../.gitbook/assets/preferences-citation-key-generator.png" alt="Citation key generator preferences" data-size="original">
 3. Change the default pattern to `[authors][camel]`
 
-    <img src="../.gitbook/assets/preferences-citation-key-generator-authors-camel (8).png" alt="Citation key generator preferences - authors camel" data-size="original">
+    <img src="../.gitbook/assets/preferences-citation-key-generator-authors-camel.png" alt="Citation key generator preferences - authors camel" data-size="original">
 4. Press "Enter" (forgetting to do this is a leading cause of puzzlement)
 5. Click "Save"
 
@@ -185,7 +185,7 @@ To change the citation key patterns for a single library to `[auth][shortyear]`,
 
 1. Make sure the library is open and selected in the JabRef main window
 
-    <img src="../.gitbook/assets/main-screen-selected-library (7).png" alt="Main screen selected library" data-size="original">
+    <img src="../.gitbook/assets/main-screen-selected-library.png" alt="Main screen selected library" data-size="original">
 2. From the "Library" menu, open "Library properties"
 
     <img src="../.gitbook/assets/library-menu.jpeg" alt="Library Citation key patterns" data-size="original">

--- a/en/setup/customentrytypes.md
+++ b/en/setup/customentrytypes.md
@@ -6,7 +6,7 @@ When customizing an entry type, you both define how its entry editor should look
 
 ## Using the entry customization dialog
 
-![Screenshot of the entry customization dialog](<../.gitbook/assets/jabrefcustomentrytypes (6).png>)
+![Screenshot of the entry customization dialog](<../.gitbook/assets/jabrefcustomentrytypes.png>)
 
 The entry customization interface is divided into two areas. On the left side all entry types (including any custom types) are listed. If you select a type from the left side, the right area shows all fields for the selected entry.
 

--- a/en/setup/externalfiletypes.md
+++ b/en/setup/externalfiletypes.md
@@ -8,4 +8,4 @@ For each file link, a file type must be chosen, to determine what icon should be
 
 A file type is specified by a graphical icon, a name, a file extension and an application to view the files. On Windows, the name of the application can be omitted in order to use Window's default viewer instead.
 
-<figure><img src="../.gitbook/assets/Manage external file types (1).png" alt=""><figcaption><p>Manage external file types</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/Manage external file types.png" alt=""><figcaption><p>Manage external file types</p></figcaption></figure>

--- a/en/setup/preview.md
+++ b/en/setup/preview.md
@@ -4,7 +4,7 @@
 
 The **Entry Preview** is located inside the **Entry Editor** (except when navigated to the `File annotations` or `{} biblatex source` tab):
 
-![Entry Preview](<../.gitbook/assets/entryeditor-preview (1).png>)
+![Entry Preview](<../.gitbook/assets/entryeditor-preview.png>)
 
 You can display the entry preview as a separate tab (see screenshot above) by checking the box `Show preview as a tab in entry editor` in the entry preview settings `Options > Preferences > Entry preview > Current Preview` (see screenshot below).
 
@@ -12,7 +12,7 @@ You can display the entry preview as a separate tab (see screenshot above) by ch
 
 The entry preview displays either the **Customized Preview Style** or a certain **Citation Style**. You can select the styles that should be available for display in **Options → Preferences → Entry preview**. In `Available` you find all styles selectable for display, in `Selected` all styles already selected for display:
 
-![Entry Preview Settings](<../.gitbook/assets/entryeditor-preview-settings (1).png>)
+![Entry Preview Settings](<../.gitbook/assets/entryeditor-preview-settings.png>)
 
 You can switch between all selected styles (customized preview and citation styles) in the entry preview in the main window by pressing `F9`.
 


### PR DESCRIPTION
https://github.com/UmbrellaDocs/linkspector parses Markdown directly (and used Chrome as client) whereas [lychee](https://github.com/lycheeverse/lychee) converts markdown to html.