### PR TITLE
Add howto for local clone

### DIFF
--- a/en/contributing/README.md
+++ b/en/contributing/README.md
@@ -1,16 +1,48 @@
-# Contribute to JabRef
+# Contribute to JabRef [![Join the chat at https://gitter.im/JabRef/jabref](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/JabRef/jabref)
 
 We are really happy that you are interested in contributing to JabRef. Please take your time to look around here. We especially invite you to look into our [community members page](https://discourse.jabref.org/t/community-members/1868?u=koppor) where members introduce themselves.
 
-**I would like to improve the help page. What are the steps?** [![Join the chat at https://gitter.im/JabRef/jabref](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/JabRef/jabref)
+**I would like to try out a feature introduced at pull request. What are the steps?**
 
-Please use the "Edit on GitHub" link in the upper right corner. Then, follow [GitHub's guide to edit files in other user's repository](https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files#editing-files-in-another-users-repository).
+In JabRef, there are dozens of bug fixes and new features introduced using GitHub's pull request mechansim.
+You can browse all at <https://github.com/JabRef/jabref/pulls>.
+The JabRef team really welcomes users to try out these additions and to comment on them.
+Getting in improvements at this stage is much easier than fixing afterwards.
 
-**I would like to help to translate JabRef to another language. How do I get started?** [![Join the chat at https://gitter.im/JabRef/jabref](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/JabRef/jabref)
+If you and the command line are friends, then it is very easy to try out pull requests and give feedback.
+In the following, we try to give a minimal set of installation instructions to be able to run a contribution from a fork.
+
+Prerequisites:
+
+- [`git`](https://git-scm.com/) - The version control system
+- [GitHubCLI](https://cli.github.com/) - A command-line client to GitHub install it using the installer linked from their [homepage]((https://cli.github.com/)) or [the commands given at the installation hints](https://github.com/cli/cli#installation).
+- A JabRef project checkout. On Windows, we recommend:
+  - `mkdir c:\git-repositories`
+  - `cd c:\git-repositories`
+  - `git clone --recurse-submodules https://github.com/JabRef/jabref.git JabRef`
+  - `cd JabRef`
+- [`gg.cmd`](https://github.com/eirikb/gg) - A cross-platform and cross-architecture version manager. Download [`gg.cmd`](https://github.com/eirikb/gg/releases/latest/download/gg.cmd) and store it in the `JabRef` directory
+
+Try a branch:
+
+1. `cd` into the `JabRef` directory: `cd c:\git-repositories\JabRef`
+2. Checkout out the pull request: `gh pr checkout 13111` - where `13111` is the PR number, in this case [pr#13111](https://github.com/JabRef/jabref/pull/13111)
+3. Compile and run JabRef `gg.cmd gradle run :jabgui:run` (on Linux and macOS, you need to prefix it with `sh`: `gg.cmd gradle run :jabgui:run`). This will also download the necessary JDK and gradle distribution. In the first run, please give the system about 4 minutes until the GUI is shown.
+
+Alternatives:
+
+1. You "just" need a JDK installed to run `./gradlew`: Gradle automatically downloads the JDK
+2. You can use the "usual" `git clone`, `git remote add ...`, `git fetch ...`, and `git checkout ...` commands to checkout a pull request from a fork.
+
+**I would like to improve the help page. What are the steps?**
+
+Please see [How to Improve the Help Page](how-to-improve-the-help-page.md)
+
+**I would like to help to translate JabRef to another language. How do I get started?**
 
 We encourage you to read about [translating the JabRef user interface](how-to-translate-the-ui.md).
 
-**I want to keep Wikipedia pages up-to-date** [![Join the chat at https://gitter.im/JabRef/jabref](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/JabRef/jabref)
+**I would like to keep Wikipedia pages up-to-date**
 
 JabRef improves -- and Wikipedia pages should keep up!
 
@@ -31,7 +63,7 @@ For changes in a specific language, go to the related page, and simply click on 
 
 If there is no page for your own language, you can easily create one.
 
-**I have some cool feature requests** [![Discourse](https://img.shields.io/badge/discourse-online-green.svg)](https://discourse.jabref.org/c/features/6)
+**I have some cool feature requests**
 
 [Come discuss it!](http://discourse.jabref.org)
 
@@ -40,8 +72,8 @@ If there is no page for your own language, you can easily create one.
 Donations keep us going! You can use PayPal or bank transfers. Your institution/company can contribute too, through bank transfer for example. All details are provided at [https://donations.jabref.org](https://donations.jabref.org).
 
 Our team consists of volunteers. To provide better support, we are currently trying to get a funded developer on board. Please consider donating money!
-{% endtab %}
 
 **I would like to contribute code. How to?**
 
 Please head to our [Contributing Guide](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md#contributing).
+


### PR DESCRIPTION
I like [ `gg.cmd`](https://github.com/eirikb/gg) more than `mise`, because `gg.cmd` does not need any installation - and the same (!) file works on Windows, macOS, and Linux.

Here a proposal to guide non-developers to try out pull requests.