### PR TITLE
Fix build instructions

### DIFF
--- a/en/installation.md
+++ b/en/installation.md
@@ -148,8 +148,10 @@ cd jabref
 ./gradlew installDist
 jabgui/build/install/jabgui/bin/jabgui
 ```
+On Windows, replace the last command with `gradlew.bat run`.
 
 In a nutshell, you clone the latest snapshot of JabRef into `jabref` directory, initialize and update all its submodules, change directory to `jabref`, build the application, and run it.
 
-To restart JabRef, rerun the last command, which should work in Linux and MacOS and when using PowerShell in Windows.
+To restart JabRef, rerun the last command.
+
 

--- a/en/installation.md
+++ b/en/installation.md
@@ -136,23 +136,30 @@ This is one the one hand a font problem and second a lognstanding [JavaFX bug](h
 {% endtab %}
 {% endtabs %}
 
-## Building From Source
+## Building from source
 
 This method is mainly for package maintainers and users who would like to build the latest snapshots of JabRef directly from the source. If you want to setup JabRef for development, follow the instructions for [setting up a workspace](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace).
 
-To build JabRef from source, you first need to have a working Java Development Kit (see above link for details) and Git installed on your system. After installing the two requirements, you open a terminal window (i.e., a command prompt) and type the following:
+To build JabRef from source, you first need to have a working Java Development Kit (see above link for details) and Git installed on your system. After installing the requirements, you open a terminal window (i.e., a command prompt) and type the following:
 
 ```shell
 git clone --recurse-submodules --depth=10 https://github.com/JabRef/jabref
 cd jabref
-./gradlew installDist
-jabgui/build/install/jabgui/bin/jabgui
+./gradlew jabgui:jpackage
 ```
 
-On Windows, replace the last command with `gradlew.bat run`.
+In a nutshell, you clone the latest snapshot of JabRef into `jabref` directory, initialize and update all its submodules, change directory to `jabref`, and build the application.
 
-In a nutshell, you clone the latest snapshot of JabRef into `jabref` directory, initialize and update all its submodules, change directory to `jabref`, build the application, and run it.
+The executable file will be written to an OS-specific subdirectory of `jabgui/build/packages`. On Windows, this would be `jabgui/build/packages/windows-latest/JabRef/JabRef.exe`.
 
-To restart JabRef, rerun the last command.
+## Running from source
+
+To run from source without building an executable, type the following in a terminal window:
+
+```shell
+./gradlew jabgui:run
+```
+
+
 
 

--- a/en/installation.md
+++ b/en/installation.md
@@ -145,7 +145,7 @@ To build JabRef from source, you first need to have a working Java Development K
 ```shell
 git clone --recurse-submodules --depth=10 https://github.com/JabRef/jabref
 cd jabref
-./gradlew jabgui:jpackage
+./gradlew :jabgui:jpackage
 ```
 
 In a nutshell, you clone the latest snapshot of JabRef into `jabref` directory, initialize and update all its submodules, change directory to `jabref`, and build the application.
@@ -157,9 +157,5 @@ The executable file will be written to an OS-specific subdirectory of `jabgui/bu
 To run from source without building an executable, type the following in a terminal window:
 
 ```shell
-./gradlew jabgui:run
+./gradlew :jabgui:run
 ```
-
-
-
-

--- a/en/installation.md
+++ b/en/installation.md
@@ -148,6 +148,7 @@ cd jabref
 ./gradlew installDist
 jabgui/build/install/jabgui/bin/jabgui
 ```
+
 On Windows, replace the last command with `gradlew.bat run`.
 
 In a nutshell, you clone the latest snapshot of JabRef into `jabref` directory, initialize and update all its submodules, change directory to `jabref`, build the application, and run it.

--- a/en/installation.md
+++ b/en/installation.md
@@ -145,10 +145,11 @@ To build JabRef from source, you first need to have a working Java Development K
 ```shell
 git clone --recurse-submodules --depth=10 https://github.com/JabRef/jabref
 cd jabref
-./gradlew assemble
-./gradlew jlink
+./gradlew installDist
+jabgui/build/install/jabgui/bin/jabgui
 ```
 
-In a nutshell, you clone the latest snapshot of JabRef into `jabref` directory, change directory to `jabref`, initialize and update all the submodules (dependencies) of JabRef, assemble them to be built via JDK and finally build and link them together.
+In a nutshell, you clone the latest snapshot of JabRef into `jabref` directory, initialize and update all its submodules, change directory to `jabref`, build the application, and run it.
 
-The output should be the `jabgui/build/image` subdirectory that contains the JabRef binary with all of its Java dependencies. To start JabRef, you need to run `bin/JabRef` (in Linux and MacOS) or `bin/JabRef.bat` (in Windows) under `jabgui/build/image` subdirectory.
+To restart JabRef, rerun the last command, which should work in Linux and MacOS and when using PowerShell in Windows.
+


### PR DESCRIPTION
This addresses issue #578. (Fixes #578)

The reason I don't recommend `gradlew run` is that runs all the modules and has to be exited with Ctrl + C.

FYI I removed the reference to `jabgui.bat` because that script failed when I ran it in a Windows CMD shell or in PowerShell. I will file an issue in the JabRef repo.

