### PR TITLE
Enlarge Screenshots in main-window.md

### DIFF
--- a/en/advanced/main-window.md
+++ b/en/advanced/main-window.md
@@ -5,14 +5,17 @@ This is the main window from where you work with your databases. Below the menub
 ### Entry Table Preferences
 
 * You decide which fields are shown in the entry table by checking the fields you want to see in the **File → Preferences → Entry table** dialog.
+
   ![Entry table configuration dialog](entry-table.png)
 
 ### Entry Table
 
 * Double-click a line of the entry table to edit the entry content. You can navigate the table with the arrow keys.
+
   ![Edit entry on the main table](entry-table-edit.png)
 
 * To quickly change the sort order within the entry table, click the header of a column to set it as the primary sort criterion, or reverse the sorting if it is already set. Another click will deselect the column as sorting criterion. Hold down Ctrl and click a column to add, reverse or remove it as a sub-criterion after the primary column. You can add an arbitrary number of sub-criteria, but only three levels will be stored for the next time you start JabRef.
 
 * Adjust the width of each column by dragging the borders between their headers.
+
   ![Adjust width of columns](adjust-width-of-columns.png)


### PR DESCRIPTION
My prior commit https://github.com/JabRef/user-documentation/pull/599 made it look like this:
<img width="851" height="611" alt="grafik" src="https://github.com/user-attachments/assets/c58abc55-92b6-4cba-9927-ac3c260b9149" />
So this PR is a revert fix.