### PR TITLE
Add hint for non-functional browser extension on Chrome

### DIFF
--- a/en/collect/jabref-browser-extension.md
+++ b/en/collect/jabref-browser-extension.md
@@ -8,7 +8,7 @@ description: >-
 
 > [Firefox](https://addons.mozilla.org/en-US/firefox/addon/jabref/?src=external-github) - [Chrome](https://chrome.google.com/webstore/detail/jabref-browser-extension/bifehkofibaamoeaopjglfkddgkijdlh) - [Edge](https://microsoftedge.microsoft.com/addons/detail/pgkajmkfgbehiomipedjhoddkejohfna) - [Vivaldi](https://chrome.google.com/webstore/detail/jabref-browser-extension/bifehkofibaamoeaopjglfkddgkijdlh)
 
-{% hint style="warning" %} The browser extension is currently not supported on Chrome, as of [issue 616](https://github.com/JabRef/JabRef-Browser-Extension/issues/616). {% endhint %}
+{% hint style="warning" %} The browser extension is currently non-functional on Chrome, as of [issue 616](https://github.com/JabRef/JabRef-Browser-Extension/issues/616). {% endhint %}
 
 JabRef offers an official browser extension. It automatically identifies and extracts bibliographic information on websites and sends them to JabRef with one click.
 


### PR DESCRIPTION
We should add a hint to avoid users running into expected trouble.