### PR TITLE
Add FAQ entry for JabRef not starting on Wayland

### DIFF
--- a/en/faq/linux.md
+++ b/en/faq/linux.md
@@ -31,3 +31,8 @@ In the background, JabRef uses [JavaFX](https://en.wikipedia.org/wiki/JavaFX). A
 ## Where can I find JabRef's log files?
 
 A: On Linux, the path to the log files is `~/.local/share/jabref/logs/$version/`
+
+## JabRef does not start on a Wayland-based system. What can I do?
+
+JabRef relies on [XWayland](https://wayland.freedesktop.org/docs/html/ch05.html) to run in Wayland environments. If your system is missing this dependency, the application will fail to launch (often showing an `Unable to open DISPLAY` error). To fix this, simply install XWayland using your distribution's package manager.
+For example, on Debian/Ubuntu systems, run: `sudo apt install xwayland`

--- a/en/faq/linux.md
+++ b/en/faq/linux.md
@@ -6,6 +6,12 @@ Yes, there is. See [http://askubuntu.com/a/721387/196423](http://askubuntu.com/a
 
 ## JabRef does not start under Linux! What can I do?
 
+### Wayland-based systems
+
+JabRef relies on [XWayland](https://wayland.freedesktop.org/docs/html/ch05.html) to run in Wayland environments.
+If your system is missing this dependency, the application will fail to launch (often showing an `Unable to open DISPLAY` error).
+To fix this, install `xwayland` using your distribution's package manager.
+
 ### JabRef 5.x
 
 JabRef comes with a bundled JRE. There is no need to install Java separately. Thus, there should be no issues at start up.
@@ -17,10 +23,6 @@ JabRef comes with a bundled JRE. There is no need to install Java separately. Th
 Please follow the steps provided on our [installation page](../installation.md). JabRef 4.x does not run under Java 9 or newer. See [https://github.com/JabRef/jabref/issues/2594](https://github.com/JabRef/jabref/issues/2594)
 
 You might see the error message `Error: Could not find or load main class org.jabref.JabRefMain`. This means, you do not have [JavaFX](https://en.wikipedia.org/wiki/JavaFX) support activated in your Java runtime environment. This typically happens if you use [OpenJDK](http://openjdk.java.net/), where one needs to setup [OpenJFX](https://wiki.openjdk.java.net/display/OpenJFX/Main) separately.
-
-## Wayland-based systems
-
-JabRef relies on [XWayland](https://wayland.freedesktop.org/docs/html/ch05.html) to run in Wayland environments. If your system is missing this dependency, the application will fail to launch (often showing an `Unable to open DISPLAY` error). To fix this, simply install XWayland using your distribution's package manager.
 
 ## I am on Debian/Ubuntu and clicking on the JabRef icon works, but I cannot start JabRef from the command line. What is wrong?
 

--- a/en/faq/linux.md
+++ b/en/faq/linux.md
@@ -20,9 +20,7 @@ You might see the error message `Error: Could not find or load main class org.ja
 
 ### Wayland-based systems
 
-JabRef relies on [XWayland](https://packages.debian.org/stable/xwayland) to run in Wayland environments. If your system is missing this dependency, the application will fail to launch (often showing an `Unable to open DISPLAY` error). To fix this, simply install XWayland using your distribution's package manager.
-
-For example, on Debian/Ubuntu systems, run: `sudo apt install xwayland`
+JabRef relies on [XWayland](https://wayland.freedesktop.org/docs/html/ch05.html) to run in Wayland environments. If your system is missing this dependency, the application will fail to launch (often showing an `Unable to open DISPLAY` error). To fix this, simply install XWayland using your distribution's package manager.
 
 ## I am on Debian/Ubuntu and clicking on the JabRef icon works, but I cannot start JabRef from the command line. What is wrong?
 
@@ -37,8 +35,3 @@ In the background, JabRef uses [JavaFX](https://en.wikipedia.org/wiki/JavaFX). A
 ## Where can I find JabRef's log files?
 
 A: On Linux, the path to the log files is `~/.local/share/jabref/logs/$version/`
-
-## JabRef does not start on a Wayland-based system. What can I do?
-
-JabRef relies on [XWayland](https://wayland.freedesktop.org/docs/html/ch05.html) to run in Wayland environments. If your system is missing this dependency, the application will fail to launch (often showing an `Unable to open DISPLAY` error). To fix this, simply install XWayland using your distribution's package manager.
-For example, on Debian/Ubuntu systems, run: `sudo apt install xwayland`

--- a/en/faq/linux.md
+++ b/en/faq/linux.md
@@ -18,7 +18,7 @@ Please follow the steps provided on our [installation page](../installation.md).
 
 You might see the error message `Error: Could not find or load main class org.jabref.JabRefMain`. This means, you do not have [JavaFX](https://en.wikipedia.org/wiki/JavaFX) support activated in your Java runtime environment. This typically happens if you use [OpenJDK](http://openjdk.java.net/), where one needs to setup [OpenJFX](https://wiki.openjdk.java.net/display/OpenJFX/Main) separately.
 
-### Wayland-based systems
+## Wayland-based systems
 
 JabRef relies on [XWayland](https://wayland.freedesktop.org/docs/html/ch05.html) to run in Wayland environments. If your system is missing this dependency, the application will fail to launch (often showing an `Unable to open DISPLAY` error). To fix this, simply install XWayland using your distribution's package manager.
 

--- a/en/faq/linux.md
+++ b/en/faq/linux.md
@@ -18,6 +18,12 @@ Please follow the steps provided on our [installation page](../installation.md).
 
 You might see the error message `Error: Could not find or load main class org.jabref.JabRefMain`. This means, you do not have [JavaFX](https://en.wikipedia.org/wiki/JavaFX) support activated in your Java runtime environment. This typically happens if you use [OpenJDK](http://openjdk.java.net/), where one needs to setup [OpenJFX](https://wiki.openjdk.java.net/display/OpenJFX/Main) separately.
 
+### Wayland-based systems
+
+JabRef relies on [XWayland](https://packages.debian.org/stable/xwayland) to run in Wayland environments. If your system is missing this dependency, the application will fail to launch (often showing an `Unable to open DISPLAY` error). To fix this, simply install XWayland using your distribution's package manager.
+
+For example, on Debian/Ubuntu systems, run: `sudo apt install xwayland`
+
 ## I am on Debian/Ubuntu and clicking on the JabRef icon works, but I cannot start JabRef from the command line. What is wrong?
 
 You have several Java Virtual Machines installed, and under the command line the wrong one is chosen. Have a look at the previous question that tells you how to change the virtual machine used.


### PR DESCRIPTION
This PR adds a FAQ entry to linux.md documenting that JabRef requires XWayland to run on Wayland-based systems, as discussed in JabRef/jabref#11489.