### PR TITLE
docs(editors): link Kile, add Kate to JabRef-compatible editors

### DIFF
--- a/en/advanced/resources.md
+++ b/en/advanced/resources.md
@@ -5,7 +5,8 @@
 JabRef can push entries, i.e., insert `\cite{key}` commands, to the following text editors:
 
 * [Emacs](https://www.gnu.org/software/emacs/)
-* [LyX/Kile](http://www.lyx.org/)
+* [Kate](https://apps.kde.org/en-gb/kate/)
+* [LyX](http://www.lyx.org/)/[Kile](https://apps.kde.org/en/kile/)
 * [TeXstudio](http://www.texstudio.org/)
 * [Texmaker](http://www.xm1math.net/texmaker/)
 * [Vim](http://www.vim.org/)


### PR DESCRIPTION
Closes #592

## What

Two small docs improvements requested in #592:

1. Link the existing Kile mention to https://apps.kde.org/en/kile/.
2. Add Kate (https://apps.kde.org/en-gb/kate/) to the list of
   JabRef-compatible text editors, mirroring the existing entry
   style.

## Why

The reporter pointed out that Kile is mentioned without a link, and
that Kate (also KDE, also JabRef-compatible if Kile is) was missing
from the list entirely.

## AI disclosure

Per project norms — this PR is AI-generated and unattended, written by
a Cursor Anthropic Claude Opus 4.7 agent under @adv0r as a personal
token-burn initiative before my Cursor billing cycle ends. Opened as
**draft** for review. Happy to iterate.

Made with [Cursor](https://cursor.com)