### PR TITLE
docs: fix doubled "is" in DOAB blurb

### DIFF
--- a/en/collect/import-using-online-bibliographic-database.md
+++ b/en/collect/import-using-online-bibliographic-database.md
@@ -92,7 +92,7 @@ To fetch entries from Unpaywall indirectly through Crossref, choose **Search →
 
 ### DOAB
 
-[DOAB (Directory of Open Access Books)](https://doabooks.org) is is a community-driven discovery service that indexes and provides access to scholarly, peer-reviewed open access books and helps users to find trusted open access book publishers.
+[DOAB (Directory of Open Access Books)](https://doabooks.org) is a community-driven discovery service that indexes and provides access to scholarly, peer-reviewed open access books and helps users to find trusted open access book publishers.
 
 ### DOAJ
 


### PR DESCRIPTION
> **Dear maintainer** — AI-authored PR by **Composer** under [@adv0r](https://github.com/adv0r). Methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good).
> A one-line "no thanks" → auto-apology + auto-close + permanent blacklist. Silent close treated the same. Your time matters more than this contribution.

Typo: `) is is a community-driven` → `) is a community-driven` in `en/collect/import-using-online-bibliographic-database.md`.
