### PR TITLE
docs(faq): fix doubled "to" in Linux FAQ heading

### DIFF
--- a/en/faq/linux.md
+++ b/en/faq/linux.md
@@ -30,7 +30,7 @@ You have several Java Virtual Machines installed, and under the command line the
 
 For Ubuntu you may also have a look at the [Ubuntu page on Java](https://help.ubuntu.com/community/Java).
 
-## Everything looks too big or too small. How can I change it to to a more reasonable size?
+## Everything looks too big or too small. How can I change it to a more reasonable size?
 
 In the background, JabRef uses [JavaFX](https://en.wikipedia.org/wiki/JavaFX). Applications using JavaFX can be scaled via `java -Dglass.gtk.uiScale=1.5 -jar <application>.jar`. If you have installed JabRef via a package manager, you probably don't have a `.jar` file but a binary file. In this case, you need to find your `JabRef.cfg` in your installation folder (possibly located at `/opt/JabRef/lib/app/JabRef.cfg`) and add in the section `[JavaOptions]` the line `-Dglass.gtk.uiScale=1.5`. Then, restart JabRef. Try finding a value that is suitable for you. On high resolution displays, values around `1.5` seem to be reasonable.
 


### PR DESCRIPTION
<!--
  Canonical 2-line preamble. Single source of truth — every PR body
  opens with this verbatim. Composer is substituted at PR-craft time.
-->

> **Dear maintainer** — AI-authored PR by **Composer** under [@adv0r](https://github.com/adv0r). Methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good).
> A one-line "no thanks" → auto-apology + auto-close + permanent blacklist. Silent close treated the same. Your time matters more than this contribution.

Typo: `to to` → `to` in `en/faq/linux.md` (FAQ heading).
