### PR TITLE
docs(cite): fix doubled "is" in bibtex intro

### DIFF
--- a/en/cite/bibtex-and-biblatex.md
+++ b/en/cite/bibtex-and-biblatex.md
@@ -4,7 +4,7 @@ description: The data format of JabRef is BibTeX. In addtion JabRef also support
 
 # BibTeX and biblatex
 
-JabRef is is a program for working with BibTeX and biblatex libraries. JabRef program uses no separate internal file format but directly works with BibTeX and biblatex. That means, your BibTeX/biblatex file is kept as is when opening in JabRef and saving again: You normally load and save your libraries directly in the BibTeX/biblatex`.bib` format. In addition, you can also [import](../collect/) and export bibliography libraries in a number of other formats into JabRef.
+JabRef is a program for working with BibTeX and biblatex libraries. JabRef program uses no separate internal file format but directly works with BibTeX and biblatex. That means, your BibTeX/biblatex file is kept as is when opening in JabRef and saving again: You normally load and save your libraries directly in the BibTeX/biblatex`.bib` format. In addition, you can also [import](../collect/) and export bibliography libraries in a number of other formats into JabRef.
 
 The library mode can be changed in the [library properties](../setup/databaseproperties.md).
 


### PR DESCRIPTION
<!--
  Canonical 2-line preamble. Single source of truth — every PR body
  opens with this verbatim. Composer is substituted at PR-craft time.
-->

> **Dear maintainer** — AI-authored PR by **Composer** under [@adv0r](https://github.com/adv0r). Methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good).
> A one-line "no thanks" → auto-apology + auto-close + permanent blacklist. Silent close treated the same. Your time matters more than this contribution.

Typo: `is is` → `is` in `en/cite/bibtex-and-biblatex.md` (opening sentence).
