### PR TITLE
Fix markdownlint errors across docs

### DIFF
--- a/en/advanced/OCR.md
+++ b/en/advanced/OCR.md
@@ -16,16 +16,16 @@ OCRmyPDF must be installed on your system to use this feature.
 2. Open the General Tab of the Entry Editor.
 3. Right-click on the File and select "Perform OCR and embed text into new PDF file". ![perform-ocr.png](../.gitbook/assets/perform-ocr.png)
 
-*   After performing OCR, JabRef creates a new PDF file with the OCR text embedded, and it will be linked to all the entries that have the old file linked to them. The original scanned PDF will remain unchanged.
+* After performing OCR, JabRef creates a new PDF file with the OCR text embedded, and it will be linked to all the entries that have the old file linked to them. The original scanned PDF will remain unchanged.
 
     ![original-and-ocred-files.png](../.gitbook/assets/original-and-ocred-files.png)
-*   Now you can select and search text in the new PDF file.
+* Now you can select and search text in the new PDF file.
 
     ![comparison-between-original-and-ocred-file.png](../.gitbook/assets/comparison-between-original-and-ocred-file.png)
 
 ## OCR Preferences
 
-*   The OCR preferences can be accessed via **File → Preferences → OCR**.
+* The OCR preferences can be accessed via **File → Preferences → OCR**.
 
     ![ocr-preferences.png](../.gitbook/assets/ocr-preferences.png)
 
@@ -39,13 +39,13 @@ Performing OCR will fail if wrong engine path is provided, make sure that the co
 * If OCRmyPDF is installed in a non-standard location, or if it needs to be invoked through Python, you can configure the path manually in this preference tab.
 * There are three ways to set the engine path:
 
-1.  **Type the path manually**: Enter the path directly into the text field. This can be a bare command name (e.g. `ocrmypdf` or `python -m ocrmypdf`) if it is available on your system PATH, or a full absolute path to the executable (e.g. `/home/user/.local/bin/ocrmypdf`).
+1. **Type the path manually**: Enter the path directly into the text field. This can be a bare command name (e.g. `ocrmypdf` or `python -m ocrmypdf`) if it is available on your system PATH, or a full absolute path to the executable (e.g. `/home/user/.local/bin/ocrmypdf`).
 
     ![text-field-for-engine-path.png](../.gitbook/assets/text-field-for-engine-path.png)
-2.  **Browse**: Click the folder icon to open a file chooser and navigate to the OCRmyPDF executable on your system.
+2. **Browse**: Click the folder icon to open a file chooser and navigate to the OCRmyPDF executable on your system.
 
     ![browse-engine-path-button.png](../.gitbook/assets/browse-engine-path-button.png)
-3.  **Auto-detect**: Click the magnifier icon to have JabRef automatically search for a working OCRmyPDF installation. JabRef will try the following commands in order and use the first one that works:
+3. **Auto-detect**: Click the magnifier icon to have JabRef automatically search for a working OCRmyPDF installation. JabRef will try the following commands in order and use the first one that works:
 
     ![auto-detect-engine-path-button.png](../.gitbook/assets/auto-detect-engine-path-button.png)
 

--- a/en/advanced/README.md
+++ b/en/advanced/README.md
@@ -24,7 +24,7 @@
 [externalfiles.md](externalfiles.md)
 {% endcontent-ref %}
 
-{% content-ref url="https://github.com/JabRef/user-documentation/blob/main/en/advanced/OCR.md" %}
+{% content-ref url="<https://github.com/JabRef/user-documentation/blob/main/en/advanced/OCR.md>" %}
 [https://github.com/JabRef/user-documentation/blob/main/en/advanced/OCR.md](https://github.com/JabRef/user-documentation/blob/main/en/advanced/OCR.md)
 {% endcontent-ref %}
 

--- a/en/advanced/how-to-expand-firstnames.md
+++ b/en/advanced/how-to-expand-firstnames.md
@@ -18,15 +18,15 @@ Sometimes, one has a BibTeX/biblatex entry with abbreviated short names:
 
 Now, one wants to have the full first names. In case, there is a DOI available, this is as simple as the following steps:
 
-1.  Determine the DOI: Switch to the "General" tab and click on "Look up DOI"
+1. Determine the DOI: Switch to the "General" tab and click on "Look up DOI"
 
     ![Screenshot of determine DOI](../.gitbook/assets/expand-firstnames-step-1.png)
-2.  Fetch BibTeX data from the DOI: Click on "Get BibTeX data from DOI"
+2. Fetch BibTeX data from the DOI: Click on "Get BibTeX data from DOI"
 
     ![Screenshot of get BibTeX data from DOI](../.gitbook/assets/expand-firstnames-step-2.png)
-3.  A popup appears. Select which data you want to merge into the eixting entry
+3. A popup appears. Select which data you want to merge into the eixting entry
 
     ![Screenshot of Merge Entries Dialog](../.gitbook/assets/expand-firstnames-step-3.png)
-4.  Now the first names are expanded:
+4. Now the first names are expanded:
 
     ![Screenshot of Result](../.gitbook/assets/expand-firstnames-step-4.png)

--- a/en/advanced/knowledge/medlineris.md
+++ b/en/advanced/knowledge/medlineris.md
@@ -9,100 +9,100 @@ In other sources, you might encounter "MedlinePlain" as a synonym for "Medline \
 | Field | Medline \(txt\) | Medline \(XML\) | RIS |
 | :--- | :--- | :--- | :--- |
 | Abstract | **AB** | **Abstract / AbstractText** | **AB** |
-| Affiliation | **AD** |  |  |
-| Article Date |  | **ArticleDate** |  |
-| Article Identifier | **AID** | **Article** |  |
-| Article Title |  | **ArticleTitle** |  |
+| Affiliation | **AD** | | |
+| Article Date | | **ArticleDate** | |
+| Article Identifier | **AID** | **Article** | |
+| Article Title | | **ArticleTitle** | |
 | Author | **AU** | **AuthorList** | **AU/A1** |
-| Author Identifier | **AUID** |  |  |
-| Book Title | **BTI** |  | **BT** |
-| Chemical List |  | **ChemicalList** |  |
-| Citation Subset |  | **CitationSubset** |  |
-| Collection Title | **CTI** |  |  |
-| Collaborators |  |  | **A3** |
-| Comments Corrections List |  | **CommentsCorrectionsList** |  |
-| Corporate Author | **CN** |  |  |
-| Copyright Information |  | **CopyrightInformation** |  |
-| Create Date | **CRDT** |  |  |
-| Country |  | **Country** |  |
-| Data Bank List |  | **DataBankList** |  |
-| Date Completed | **DCOM** | **DateCompleted** |  |
-| Date Created | **DA** | **DateCreated** |  |
-| Date Last Revised | **LR** | **DateRevised** |  |
-| Date of Electronic Publication | **DEP** |  |  |
-| Date of Publication | **DP** |  | **Y2** |
-| Delete Citation |  | **DeleteCitation** |  |
-| DOI |  |  | **DOI** |
-| Edition | **EN** |  |  |
-| Editor and Full Editor Name | **FED** |  | **ED** |
-| End |  |  | **ER** |
-| End   Page |  |  | **EP** |
-| Entrez Date | **EDAT** |  |  |
-| Full Author | **FAU** |  |  |
-| Full Personal Name as Subject | **FPS** |  |  |
-| Gene Symbol | **GS** |  |  |
-| General Note | **GN** | **GeneralNote** |  |
-| Grant List |  | **GrantList** |  |
-| Grant Number | **GR** |  |  |
-| Investigator Name and Full Investigator Name | **IR/FIR** |  |  |
-| Investigator List |  | **InvestigatorList** |  |
-| ISO Abbreviation |  | **ISOAbbreviation** |  |
-| ISBN | **ISBN** |  | **SN** |
-| ISSN | **IS** | **ISSN** |  |
-| ISSN Linking |  | **ISSNLinking** |  |
+| Author Identifier | **AUID** | | |
+| Book Title | **BTI** | | **BT** |
+| Chemical List | | **ChemicalList** | |
+| Citation Subset | | **CitationSubset** | |
+| Collection Title | **CTI** | | |
+| Collaborators | | | **A3** |
+| Comments Corrections List | | **CommentsCorrectionsList** | |
+| Corporate Author | **CN** | | |
+| Copyright Information | | **CopyrightInformation** | |
+| Create Date | **CRDT** | | |
+| Country | | **Country** | |
+| Data Bank List | | **DataBankList** | |
+| Date Completed | **DCOM** | **DateCompleted** | |
+| Date Created | **DA** | **DateCreated** | |
+| Date Last Revised | **LR** | **DateRevised** | |
+| Date of Electronic Publication | **DEP** | | |
+| Date of Publication | **DP** | | **Y2** |
+| Delete Citation | | **DeleteCitation** | |
+| DOI | | | **DOI** |
+| Edition | **EN** | | |
+| Editor and Full Editor Name | **FED** | | **ED** |
+| End | | | **ER** |
+| End   Page | | | **EP** |
+| Entrez Date | **EDAT** | | |
+| Full Author | **FAU** | | |
+| Full Personal Name as Subject | **FPS** | | |
+| Gene Symbol | **GS** | | |
+| General Note | **GN** | **GeneralNote** | |
+| Grant List | | **GrantList** | |
+| Grant Number | **GR** | | |
+| Investigator Name and Full Investigator Name | **IR/FIR** | | |
+| Investigator List | | **InvestigatorList** | |
+| ISO Abbreviation | | **ISOAbbreviation** | |
+| ISBN | **ISBN** | | **SN** |
+| ISSN | **IS** | **ISSN** | |
+| ISSN Linking | | **ISSNLinking** | |
 | Issue | **IP** | **Issue** | **IS** |
-| Journal Issue |  | **JournalIssue** |  |
+| Journal Issue | | **JournalIssue** | |
 | Journal Title | **JT** | **Journal** | **JO/JF/JA** |
-| Journal Title Abbreviation | **TA** |  |  |
-| Keywords |  | **KeywordList** | **KW** |
-| Language | **LA** | **Language** |  |
-| Location Identifier | **LID** |  |  |
-| Manuscript Identifier | **MID** |  |  |
-| Medline Title Abbreviation |  | **MedlineTA** |  |
-| Medline Date |  | **MedlineDate** |  |
-| MeSH Date | **MHDA** |  |  |
-| Mesh Heading List |  | **MeshHeadingList** |  |
-| MeSH Terms | **MH** |  |  |
-| Misc |  |  | **M1-M3** |
-| NLM Unique ID | **JID** | **NlmUniqueID** |  |
-| Note |  |  | **N1** |
-| Number of References | **RF** |  |  |
-| Other Abstract and other abstract language | **OAB/OABL** | **OtherAbstract** |  |
-| Other Copyright Information | **OCI** |  |  |
-| Other ID | **OID** | **OtherID** |  |
-| Other Term | **OT** |  |  |
-| Other Term Owner | **OTO** |  |  |
-| Owner | **OWN** |  |  |
-| Pagination | **PG** | **Pagination** |  |
-| Personal Name as Subject | **PS** |  |  |
-| Personal Name as Subject List |  | **PersonalNameSubjectList** |  |
-| Place of Publication | **PL** |  |  |
-| Publication History Status | **PHST** |  |  |
-| Publication Status | **PST** |  |  |
-| Publication Type | **PT** |  |  |
-| Publication Type List |  | **PublicationTypeList** |  |
-| Publisher |  |  | **PB** |
-| Publishing Date |  | **PubDate** |  |
-| Publishing Model | **PUBM** |  |  |
-| PubMed Central Identifier | **PMCR** |  |  |
-| PubmMed Unique Identifier | **PMID** | **PMID** |  |
-| Registry Number | **RN** |  |  |
-| Reprint |  |  | **RP** |
-| Start Page |  |  | **SP** |
-| Substance Name | **NM** |  |  |
-| Supplemental Mesh List |  | **SupplMeshList** |  |
-| Secondary Source ID | **SI** |  |  |
-| Source | **SO** |  |  |
-| Space Flight Mission | **SFM** |  |  |
-| Status | **STAT** |  |  |
-| Subset | **SB** |  |  |
+| Journal Title Abbreviation | **TA** | | |
+| Keywords | | **KeywordList** | **KW** |
+| Language | **LA** | **Language** | |
+| Location Identifier | **LID** | | |
+| Manuscript Identifier | **MID** | | |
+| Medline Title Abbreviation | | **MedlineTA** | |
+| Medline Date | | **MedlineDate** | |
+| MeSH Date | **MHDA** | | |
+| Mesh Heading List | | **MeshHeadingList** | |
+| MeSH Terms | **MH** | | |
+| Misc | | | **M1-M3** |
+| NLM Unique ID | **JID** | **NlmUniqueID** | |
+| Note | | | **N1** |
+| Number of References | **RF** | | |
+| Other Abstract and other abstract language | **OAB/OABL** | **OtherAbstract** | |
+| Other Copyright Information | **OCI** | | |
+| Other ID | **OID** | **OtherID** | |
+| Other Term | **OT** | | |
+| Other Term Owner | **OTO** | | |
+| Owner | **OWN** | | |
+| Pagination | **PG** | **Pagination** | |
+| Personal Name as Subject | **PS** | | |
+| Personal Name as Subject List | | **PersonalNameSubjectList** | |
+| Place of Publication | **PL** | | |
+| Publication History Status | **PHST** | | |
+| Publication Status | **PST** | | |
+| Publication Type | **PT** | | |
+| Publication Type List | | **PublicationTypeList** | |
+| Publisher | | | **PB** |
+| Publishing Date | | **PubDate** | |
+| Publishing Model | **PUBM** | | |
+| PubMed Central Identifier | **PMCR** | | |
+| PubmMed Unique Identifier | **PMID** | **PMID** | |
+| Registry Number | **RN** | | |
+| Reprint | | | **RP** |
+| Start Page | | | **SP** |
+| Substance Name | **NM** | | |
+| Supplemental Mesh List | | **SupplMeshList** | |
+| Secondary Source ID | **SI** | | |
+| Source | **SO** | | |
+| Space Flight Mission | **SFM** | | |
+| Status | **STAT** | | |
+| Subset | **SB** | | |
 | Title | **TI** | **Title** | **TI/T1** |
-| Transliterated Title | **TT** |  |  |
-| Type |  |  | **TY** |
-| URL |  |  | **UR** |
-| User Text |  |  | **U1-U3** |
+| Transliterated Title | **TT** | | |
+| Type | | | **TY** |
+| URL | | | **UR** |
+| User Text | | | **U1-U3** |
 | Volume | **VI** | **Volume** | **VL** |
-| Volume Title | **VTI** |  |  |
-| Vernacular Title |  | **VernacularTitle** |  |
-| Year |  |  | **PY/Y1** |
+| Volume Title | **VTI** | | |
+| Vernacular Title | | **VernacularTitle** | |
+| Year | | | **PY/Y1** |
 

--- a/en/ai/ai-providers-and-api-keys.md
+++ b/en/ai/ai-providers-and-api-keys.md
@@ -80,7 +80,7 @@ If you have some money on your credit balance, you can chat with your library!
 
 To increase your credit balance on OpenAI, follow these steps:
 
-1. Add payment method [here](https://platform.openai.com/settings/organization/billing/payment-methods).
+1. Add a [payment method](https://platform.openai.com/settings/organization/billing/payment-methods).
 2. Add credit balance on [this](https://platform.openai.com/settings/organization/billing/overview) page.
 
 ### Mistral AI

--- a/en/cite/cite-as-you-write.md
+++ b/en/cite/cite-as-you-write.md
@@ -61,15 +61,15 @@ If the `format` parameter used is not supported, `biblatex` will be used.
 
 Supported values for paramter `application`:
 
-| Application | parameter  |
-|------------|-------------|
-| emacs      | `emacs`     |
-| LyX        | `lyx`       |
-| Sublime    | `sublime`   |
-| Texmaker   | `texmaker`  |
-| TeXShop    | `texshop`   |
-| TeXstudio  | `texstudio` |
-| TeXworks   | `texworks`  |
-| vim        | `vim`       |
-| VS Code    | `vscode`    |
-| WinEdt     | `winedt`    |
+| Application | parameter   |
+| ----------- | ----------- |
+| emacs       | `emacs`     |
+| LyX         | `lyx`       |
+| Sublime     | `sublime`   |
+| Texmaker    | `texmaker`  |
+| TeXShop     | `texshop`   |
+| TeXstudio   | `texstudio` |
+| TeXworks    | `texworks`  |
+| vim         | `vim`       |
+| VS Code     | `vscode`    |
+| WinEdt      | `winedt`    |

--- a/en/cite/openofficeintegration.md
+++ b/en/cite/openofficeintegration.md
@@ -40,7 +40,7 @@ To edit an already loaded custom style file or to reload changes that you made t
 
 Here is an example style file:
 
-```
+```text
 NAME
 Example style file for JabRef-OpenOffice integration.
 

--- a/en/collect/findunlinkedfiles.md
+++ b/en/collect/findunlinkedfiles.md
@@ -39,19 +39,19 @@ This information is partially outdated. Please help to improve it ([how to edit 
 {% endhint %}
 
 1. Create or open a library (AKA a `.bib` file).
-2.  Go to **Lookup -> Search for unlinked local files**. (or press `SHIFT + F7`)
+2. Go to **Lookup -> Search for unlinked local files**. (or press `SHIFT + F7`)
 
     ![FindUnlinkedFiles - Menu](../.gitbook/assets/bildschirmfoto-2021-07-05-um-19.19.09.png) ![FindUnlinkedFiles - Menu](../.gitbook/assets/findunlinkedfiles-menu-5.2.png)
-3.  The "Search for unlinked local files" dialog opens.
+3. The "Search for unlinked local files" dialog opens.
 
     <img src="../.gitbook/assets/findunlinkedfiles-window-5.2.png" alt="FindUnlinkedFiles - Initial dialog" data-size="original">
 4. Choose a start directory using the "Browse" button.
 5. Click on "Search" / "Scan directory".
-6.  In "Select files", the files not yet contained in the library are shown.
+6. In "Select files", the files not yet contained in the library are shown.
 
     <img src="../.gitbook/assets/findunlinkedfiles-foundfiles-5.2.png" alt="FindUnlinkedFiles - Found files" data-size="original">
 7. Select the entries you are interested in. Note: the button `Export selected files` allows you to export the list of the selected files (a text file containing on each line one filename with its path)
-8.  Click on `Import`.
+8. Click on `Import`.
 
     The windows close and the entry table now contains the newly-imported entries.
 9. The entry editor with the last imported entry is shown ![FindUnlinkedFiles - 08 - entry editor](../.gitbook/assets/findunlinkedfiles-08-entry-editor.png)

--- a/en/collect/newentryfromplaintext.md
+++ b/en/collect/newentryfromplaintext.md
@@ -10,22 +10,22 @@ Different parsers will lead to different results. It is strongly recommended to 
 
 Example:
 
-```
+```text
 O. Kopp, A. Armbruster, und O. Zimmermann, "Markdown Architectural Decision Records: Format and Tool Support", in 10th ZEUS Workshop, 2018.
 ```
 
-1.  Click Library and select "New entry from plain text..." Alternatively, you can press Ctrl+Shift+N.
+1. Click Library and select "New entry from plain text..." Alternatively, you can press Ctrl+Shift+N.
 
     <div align="left"><figure><picture><source srcset="../.gitbook/assets/Bild 1 - dark mode.jpg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/Bild 1.png" alt=""></picture><figcaption></figcaption></figure></div>
-2.  The "Plain Reference Parser" window opens
+2. The "Plain Reference Parser" window opens
 
     <div align="left"><figure><picture><source srcset="../.gitbook/assets/Bild 2 - Plain citations parser dialog opens - dark mode.png" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/Bild 2 - Plain citations parser dialog opens - light mode.png" alt=""></picture><figcaption></figcaption></figure></div>
-3.  Paste the reference text:
+3. Paste the reference text:
 
     <div align="left"><figure><picture><source srcset="../.gitbook/assets/Bild 3 - paste text - dark mode.png" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/new-entry-from-plain-text-step-3.png" alt=""></picture><figcaption></figcaption></figure></div>
 4. Choose a parser from the drop-down menu.
 5. Click "Add to current library"
-6.  The result is selected in the entry table:
+6. The result is selected in the entry table:
 
     <figure><picture><source srcset="../.gitbook/assets/Bild 5 - rule based result is selected in entry table - dark mode.png" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/Bild 5 - rule based result is selected in entry table - light mode.png" alt=""></picture><figcaption></figcaption></figure>
 

--- a/en/contributing/how-to-improve-the-help-page.md
+++ b/en/contributing/how-to-improve-the-help-page.md
@@ -4,7 +4,7 @@ Here is a quick start guide on how to improve help pages in the [JabRef User Doc
 
 ## Prerequisite
 
-The JabRef help pages are hosted at [GitBook](https://www.gitbook.com) with integration to GitHub, which provides version control based on [git](https://git-scm.com). In order to edit or create a JabRef help page, you need a GitHub account. You can sign up [here](https://github.com/join) for free. If you already have an account, please make sure that you are signed in.
+The JabRef help pages are hosted at [GitBook](https://www.gitbook.com) with integration to GitHub, which provides version control based on [git](https://git-scm.com). In order to edit or create a JabRef help page, you need a GitHub account. You can [sign up for a GitHub account](https://github.com/join) for free. If you already have an account, please make sure that you are signed in.
 
 ## Editing Help Pages directly in the browser
 
@@ -26,7 +26,7 @@ The window to edit the page at GitHub looks like this:
 
 ![Edit view at GitHub](../.gitbook/assets/screenshot-edit-page.png)
 
-Most text can be simply added/edited in this field as plain text. However, you can style your contribution by using [markdown](https://daringfireball.net/projects/markdown/). Markdown is a rather easy way to format text without the need for complex markup, such as with HTML. You can find an introduction to markdown [here](https://daringfireball.net/projects/markdown/) or [here](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
+Most text can be simply added/edited in this field as plain text. However, you can style your contribution by using [markdown](https://daringfireball.net/projects/markdown/). Markdown is a rather easy way to format text without the need for complex markup, such as with HTML. You can find an introduction to markdown in [Daring Fireball's Markdown documentation](https://daringfireball.net/projects/markdown/) or in [GitHub's basic writing and formatting syntax guide](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
 
 In order to review your changes, click on the "Preview changes" tab:
 

--- a/en/contributing/how-to-translate-the-ui.md
+++ b/en/contributing/how-to-translate-the-ui.md
@@ -11,10 +11,10 @@ If the JabRef interface already exists in your language, you can help improve it
 We use the service of [Crowdin](https://translate.jabref.org) to keep our translations updated. It is a service directly running in the browser and one can quickly join and start translating.
 
 * Visit [https://translate.jabref.org/](https://translate.jabref.org) to get started
-*   Select your preferred language, login, and click on _JabRef\_en.properties_
+* Select your preferred language, login, and click on _JabRef\_en.properties_
 
     <img src="../.gitbook/assets/crowdin-select-file.png" alt="Screenshot of Crowdin select file page" data-size="original">
-*   Choose the string you want to translate in the left panel (strings to be translated are listed first)
+* Choose the string you want to translate in the left panel (strings to be translated are listed first)
 
     and enter the translation in the central panel (suggestions are given at the bottom)
 

--- a/en/faq/README.md
+++ b/en/faq/README.md
@@ -46,7 +46,7 @@ A: Check your configuration. Disable some or all of following preferences:
 
 Any preference that has the potential to affect all your entries at once is worth inspecting.
 
-We collect performance related issues [here](https://github.com/JabRef/jabref/labels/dev%3A%20performance).
+We collect performance related issues in the [performance label on GitHub](https://github.com/JabRef/jabref/labels/dev%3A%20performance).
 
 ## Q: Are there any publications dealing with JabRef?
 

--- a/en/faq/osx.md
+++ b/en/faq/osx.md
@@ -16,7 +16,7 @@ A: To override that, Ctrl + Click instead, and choose "open", which gives the sa
 
 ## Q: Jabref slow/hangs on MacOS Sierra
 
-A: This is a problem some users experience in JabRef 4.0 or later on MacOS Sierra. It seems this is a bug in the networking part of Java on MacOS. You can try to add localhost explicitly to `/etc/hosts` as described [here](https://dzone.com/articles/macos-sierra-problems-with-javanetinetaddress-getl).
+A: This is a problem some users experience in JabRef 4.0 or later on MacOS Sierra. It seems this is a bug in the networking part of Java on MacOS. You can try to add localhost explicitly to `/etc/hosts` as described in [this article on macOS networking problems](https://dzone.com/articles/macos-sierra-problems-with-javanetinetaddress-getl).
 
 ## Q: Some characters are not displayed in the main table \(math characters or some upper-cased letter\)
 

--- a/en/finding-sorting-and-cleaning-entries/filelinks.md
+++ b/en/finding-sorting-and-cleaning-entries/filelinks.md
@@ -14,7 +14,7 @@ If the "file" field is included in [General fields](../setup/generalfields.md), 
 
 JabRef offers the following directory settings:
 
-1.  **File → Preferences → Linked files**, item _Main file directory._
+1. **File → Preferences → Linked files**, item _Main file directory._
 
     <img src="../.gitbook/assets/preferences-linkedfiles-5.2.png" alt="Main file directory" data-size="original">
 2. **Library → Library properties**, items _Library-specific file directory,_ and _User-specific file directory_.![Override default file directories](../.gitbook/assets/jabref-lib-properties.png)

--- a/en/installation.md
+++ b/en/installation.md
@@ -69,15 +69,15 @@ The integration with TeX editors is fine if JabRef is a deb/rpm, and the editor 
 
 Depending on your use case and needed integrations it is advisable to choose the proper packages. Watch this page for new developments on the interactions with external programs.
 
-|                       | Snap | Flatpak | deb/rpm | tar |
-| --------------------- | ---- | ------- | ------- | --- |
-| Libreoffice (system)  | ❌    | ❌       | ✅       | ✅   |
-| Libreoffice (snap)    | ❌    | ❌       | ❌       | ❌   |
-| Libreoffice (flatpak) | ❌    | ❌       | ❌       | ❌   |
-| TexShow               | ❌    | ✅       | ✅       | ✅   |
-| TexMaker              | ❌    | ✅       | ✅       | ✅   |
-| LyX                   | ❌    | ✅       | ✅       | ✅   |
-| Vim/Emacs             | ❌    | ❌       | ✅       | ✅   |
+|                        | Snap | Flatpak | deb/rpm | tar |
+| ---------------------- | ---- | ------- | ------- | --- |
+| Libreoffice (system)   | ❌   | ❌      | ✅      | ✅  |
+| Libreoffice (snap)     | ❌   | ❌      | ❌      | ❌  |
+| Libreoffice (flatpak)  | ❌   | ❌      | ❌      | ❌  |
+| TexShow                | ❌   | ✅      | ✅      | ✅  |
+| TexMaker               | ❌   | ✅      | ✅      | ✅  |
+| LyX                    | ❌   | ✅      | ✅      | ✅  |
+| Vim/Emacs              | ❌   | ❌      | ✅      | ✅  |
 
 #### Change default application to open files for JabRef snap
 

--- a/en/setup/citationkeypatterns.md
+++ b/en/setup/citationkeypatterns.md
@@ -165,13 +165,13 @@ The default key pattern is **`[auth][year]`**, and this could produce keys like 
 
 To change the citation key pattern to `[authors][camel]` for all libraries without individual settings, execute the following steps:
 
-1.  Open the preferences
+1. Open the preferences
 
     <img src="../.gitbook/assets/optionspreferences.png" alt="File → Preferences" data-size="original">
-2.  Navigate to "Citation key generator"
+2. Navigate to "Citation key generator"
 
     <img src="../.gitbook/assets/preferences-citation-key-generator.png" alt="Citation key generator preferences" data-size="original">
-3.  Change the default pattern to `[authors][camel]`
+3. Change the default pattern to `[authors][camel]`
 
     <img src="../.gitbook/assets/preferences-citation-key-generator-authors-camel.png" alt="Citation key generator preferences - authors camel" data-size="original">
 4. Press "Enter" (forgetting to do this is a leading cause of puzzlement)
@@ -181,12 +181,12 @@ To change the citation key pattern to `[authors][camel]` for all libraries witho
 
 To change the citation key patterns for a single library to `[auth][shortyear]`,
 
-1.  Make sure the library is open and selected in the JabRef main window
+1. Make sure the library is open and selected in the JabRef main window
 
     <img src="../.gitbook/assets/main-screen-selected-library.png" alt="Main screen selected library" data-size="original">
-2.  From the "Library" menu, open "Library properties"
+2. From the "Library" menu, open "Library properties"
 
     <img src="../.gitbook/assets/library-menu.jpeg" alt="Library Citation key patterns" data-size="original">
-3.  Set the pattern for the desired entry types (keeping in mind to press enter after setting each), and press the apply button.
+3. Set the pattern for the desired entry types (keeping in mind to press enter after setting each), and press the apply button.
 
     <img src="../.gitbook/assets/library-properties-citationkey.jpeg" alt="Citation key patterns" data-size="original">


### PR DESCRIPTION
## Summary
- Fixes list-marker spacing (MD030) and table column alignment (MD060) issues via `markdownlint-cli2 --fix`
- Adds missing fenced-code-block languages (MD040) in `openofficeintegration.md` and `newentryfromplaintext.md`
- Replaces non-descriptive `[here]` link text (MD059) with descriptive text in several FAQ/contributing docs
- No content/meaning changes — formatting and link text only

## Test plan
- [x] `npx markdownlint-cli2 "**/*.md" "#node_modules"` reports 0 errors locally
- [ ] Lint CI workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)