### PR TITLE
Update docs for the July 2026 entry editor redesign and other recent changes

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -17,7 +17,7 @@ Use the Search icon at the top left of this page to find what you're looking for
 ## [Collect](collect/)
 
 * Add new entries [manually](collect/add-entry-manually.md) or the based on the [reference text](collect/newentryfromplaintext.md)
-* [Search](collect/import-using-online-bibliographic-database.md) across many online scientific catalogs like CiteSeer, CrossRef, Google Scholar, IEEEXplore, INSPIRE, Medline/PubMed, MathSciNet, Springer, arXiv, and zbMATH
+* [Search](collect/import-using-online-bibliographic-database.md) across many online scientific catalogs like CrossRef, Google Scholar, IEEEXplore, INSPIRE, Medline/PubMed, MathSciNet, Springer, arXiv, and zbMATH
 * [Import options](collect/import/) for over 15 reference formats
 * Easily retrieve and link full-text articles
 * [Fetch complete bibliographic information based on identifiers](collect/add-entry-using-an-id.md) such as ISBN, DOI, PubMed-ID and arXiv-ID

--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -53,7 +53,7 @@
 * [Configuration](setup/README.md)
   * [Customize the citation key generator](setup/citationkeypatterns.md)
   * [Customize entry types](setup/customentrytypes.md)
-  * [Customize general fields](setup/generalfields.md)
+  * [Entry editor tabs](setup/generalfields.md)
   * [Customize key bindings](setup/customkeybindings.md)
   * [Library properties](setup/databaseproperties.md)
   * [Entry preview setup](setup/preview.md)

--- a/en/advanced/entryeditor/README.md
+++ b/en/advanced/entryeditor/README.md
@@ -13,19 +13,35 @@ The entry editor opens from [main window](../main-window.md) (table of entries).
 
 Then you can modify the content of the entry (see below). When done, click on the top left-hand corner of the entry editor or press **ESC** to close the entry editor and go back to the table of entries.
 
-In this panel you can specify all relevant information on a single entry. The entry editor checks the type of your entry, and lists all the fields that are required, and the ones that are optional, for referring the entry with _BibTeX_. In addition, there are several fields termed _General fields_, that are common to all entry types.
+In this panel you can specify all relevant information on a single entry. The entry editor checks the type of your entry, and lists all the fields that are required, and the ones that are optional, for referring the entry with _BibTeX_.
 
-You can fully customize which fields should be regarded as required and optional for each type of entry, and which fields appear in the General fields tabs. See [Customizing entry types](../../setup/customentrytypes.md) for more information about this.
+You can fully customize which fields should be regarded as required and optional for each type of entry. See [Customizing entry types](../../setup/customentrytypes.md) for more information about this.
 
 For information about how the fields should be filled out, see [BibTeX help](../fields.md).
 
-## The entry editor's panels
+## The entry editor's tabs
 
-The entry editor contains six panels: _Required fields_, _Optional fields_, _General_, _Abstract_, _Comments_ and _Bib(la)TeX source_, where _General_, _Abstract_ and _Comments_ can be customized (see [Customizing general fields](../../setup/generalfields.md) for details). Inside the three first panels, Tab and Shift + Tab are used to switch focus between the text fields.
+You can choose which tabs are shown, and in which order, under **File → Preferences → Entry Editor → Editor tabs**.
 
-Up to JabRef 4.1, the field was called "Review". The field name was changed to "Comments" as "Review" indicated some external reviews or some fundamental comments.
+### The Main tab
 
-Switch panels by clicking on the tabs, or navigate to the panel to the left or right using the following key combinations: Ctrl + Tab or Ctrl + + switch to the tab to the right, and Ctrl + Shift + Tab or Ctrl + - switch to the tab to the left. You can also switch to the next or previous entry by pressing Ctrl + Shift + Down or Ctrl + Shift + Up, respectively, or by clicking the appropriate toolbar button.
+The **Main** tab shows all of the entry's fields in a single scrollable list. Required and optional fields for the entry's type are listed directly, with one-click chips for adding any optional field that isn't set yet, and a free-form box for adding arbitrary (non-standard) fields.
+
+A few groups of fields are broken out into their own collapsible sections, each collapsed by default when empty and offering chips for its own unset fields:
+
+* **Identifiers** — DOI, ISBN, ISSN, ePrint/arXiv fields, PMID, MR Number
+* **Files and links** — linked files, URL, URI, URL date
+* **Bibliometrics** — citation count, ICORE ranking
+* **Comments** — the entry's comment field(s)
+* **Meta** — crossref, groups, owner, timestamps and the [special fields](../../finding-sorting-and-cleaning-entries/specialfields.md) (ranking, priority, read status, etc.)
+
+### Other tabs
+
+Besides Main, the entry editor offers: **Bib(la)TeX source** (see below), **Related articles**, **AI summary** and **AI chat** (if [AI features](../../ai/) are enabled), **File annotations**, **LaTeX citations**, **Citations**, and **Fulltext search results**.
+
+Up to JabRef 4.1, the comment field was called "Review". The field name was changed to "Comments" as "Review" indicated some external reviews or some fundamental comments.
+
+Switch tabs by clicking on them, or navigate to the tab to the left or right using the following key combinations: Ctrl + Tab or Ctrl + + switch to the tab to the right, and Ctrl + Shift + Tab or Ctrl + - switch to the tab to the left. You can also switch to the next or previous entry by pressing Ctrl + Shift + Down or Ctrl + Shift + Up, respectively, or by clicking the appropriate toolbar button.
 
 _BibTeX source_ (termed _biblatex_ _source_ in case of a biblatex library) shows how th entry will appear when the database is saved in _BibTeX_ (or _biblatex_) format. If you wish, you can edit the source directly in this panel. When you move to a different panel, press Ctrl + S or close the entry editor, JabRef will try to parse the contents of the source panel. If there are problems, you will be notified, and given the option to edit your entry further, or to revert to the former contents.
 
@@ -74,6 +90,10 @@ Pressing Ctrl + Shift + K causes the citation key for your entry to be copied to
 Press Ctrl + G or the 'gen key' button (the magic wand) to autogenerate a citation key for your entry based on the contents of its required fields.
 
 For more information on how JabRef generates citation keys, see [Customizing the citation key generator](../../setup/citationkeypatterns.md).
+
+## Jump to field
+
+Press Ctrl + J or the toolbar button to open a dialog for jumping directly to a specific field in the Main tab.
 
 ## Related Articles Tab
 

--- a/en/advanced/entryeditor/entrylinks.md
+++ b/en/advanced/entryeditor/entrylinks.md
@@ -8,7 +8,7 @@ Following fields are supported:
 * `crossref` - single entry which is cross referenced.
 * `related` - comma separated list of citation keys which are in some kind related to this entry. The type of **all** relations can be specified by a single `relatedtype` \(see [https://github.com/plk/biblatex/issues/475\#issuecomment-246931180](https://github.com/plk/biblatex/issues/475#issuecomment-246931180)\). Note: biblatex prints this information if `related` is active at the biblatex package.
 
-To use the `crossref` field, navigate to the general tab and insert the Crossref at the top.
+To use the `crossref` field, navigate to the Main tab's **Meta** section and insert the Crossref there.
 
 To use `cites` and `related`, follow these steps:
 
@@ -16,7 +16,7 @@ To use `cites` and `related`, follow these steps:
 2. Insert `related = {citationkey},`
 3. Close the entry editor
 4. Open the entry editor
-5. Navigate to "Other fields"
+5. Navigate to the Main tab
 6. There, you now see "related" with the possibilities to \(i\) navigate to the entry, \(ii\) add new related entries, \(iii\) remove related entries.
 
 ## Notes

--- a/en/advanced/entryeditor/icore-field.md
+++ b/en/advanced/entryeditor/icore-field.md
@@ -2,19 +2,19 @@
 
 The [ICORE (International CORE Conference Rankings)](https://www.core.edu.au/home) is a ranking of Computer Science conferences (A*, A, B, C). JabRef allows you to lookup a conference's ICORE rank so you can find out how highly ranked a paper's venue is.
 
-By default, the `Icore` field shows up under the `General` tab below the `DOI` field:
+By default, the `Icore` field shows up in the **Bibliometrics** section of the entry editor's Main tab, alongside the citation count:
 
 ![Icore Field In the General Tab](../../.gitbook/assets/icore-field-1.png)
 
 {% hint style="info" %}
-If you can't find it, you can [update your preferences](../../setup/generalfields.md) and add the `icore` field to the `General` tab.
+The screenshots on this page predate the entry editor redesign and still show the old "General" tab layout; the `Icore` field itself is unchanged, only its location moved to the Bibliometrics section described above.
 {% endhint %}
 
 Let's do a quick example. Add a new Entry of type `InProceedings` and enter a conference acronym in parentheses under the `Booktitle` field (we'll use SIGCOMM here).
 
 ![Booktitle field with SIGCOMM in it](../../.gitbook/assets/icore-field-2.png)
 
-Now, navigate to the General Tab and click the "Lookup conference rank" button to see the ICORE rank for the conference (which would be A*).
+Now, navigate to the Bibliometrics section of the Main tab and click the "Lookup conference rank" button to see the ICORE rank for the conference (which would be A*).
 
 ![SIGCOMM conference rank is A*](../../.gitbook/assets/icore-field-3.png)
 
@@ -24,7 +24,7 @@ In case an acronym isn't present in the title, JabRef will then use the full `Bo
 
 > Proceedings of the 3rd International Conference on Cloud Computing and Service Science, 8-10 May 2013, Aachen, Germany
 
-Copy-paste it into the `Booktitle` field, go to the `General` Tab, and click on the Lookup button again to see the conference's rank (which would be C).
+Copy-paste it into the `Booktitle` field, go to the Bibliometrics section, and click on the Lookup button again to see the conference's rank (which would be C).
 
 ![A long booktitle with conference title in it](../../.gitbook/assets/icore-field-4.png)
 

--- a/en/advanced/entryeditor/owner.md
+++ b/en/advanced/entryeditor/owner.md
@@ -4,5 +4,5 @@ JabRef can optionally mark all new entries added or imported to a library with y
 
 You can disable or enable this feature by entering **File → Preferences → General → Entry Owner**, and selecting/deselecting the line _'mark new entries with owner name'_. You can also change the name used to mark entries. By default, your user name is used. Finally, if an entry with an existing field '_owner_' is imported, the field is updated with your name if _'Overwrite'_ is checked.
 
-The owner name is added in a field called _'owner'_, which by default is visible in the **General fields** tab in the [entry editor](./).
+The owner name is added in a field called _'owner'_, which is shown in the **Meta** section of the [entry editor](./)'s Main tab.
 

--- a/en/advanced/entryeditor/timestamp.md
+++ b/en/advanced/entryeditor/timestamp.md
@@ -8,11 +8,11 @@ You can disable or enable this feature by entering **File → Preferences → Ge
 
 If an entry with a timestamp is pasted or imported, the field is updated with the current date if _'Overwrite'_ is checked. The value of the timestamp field will be updated upon changes in the entry if _'Update timestamp on modification'_ is checked.
 
-By default, the date is added in a field called _'timestamp'_, which is visible in the **General fields** tab in the [entry editor](./). You can alter the name of this field. The _date format_ can also be customized (see below).
+By default, the date is added in a field called _'timestamp'_, which is shown in the **Meta** section of the [entry editor](./)'s Main tab. You can alter the name of this field. The _date format_ can also be customized (see below).
 
 ## Usage
 
-The timestamp field can be edited in the **General fields** tab of the [entry editor](./). If you do not see these fields, enable them at [General Fields](../../setup/generalfields.md) or reset your preferences.
+The timestamp field can be edited in the **Meta** section of the Main tab in the [entry editor](./). This section is collapsed by default when it has no set fields; expand it, or use its chip, to add or edit the timestamp field.
 
 You can manually alter the value by typing in the date and time of your choice. Also, by clicking on the calendar icon located at the right end of the field, you can select the date you want in a calendar.
 

--- a/en/advanced/fields.md
+++ b/en/advanced/fields.md
@@ -108,7 +108,7 @@ Here is a list of some of the more common non-standard fields ("\*" = not direct
 To help in managing your bibliography, and extend the features of BibTeX, JabRef defines some specific fields:
 
 * [External files](externalfiles.md)
-* [General fields](../setup/generalfields.md)
+* [Entry editor tabs](../setup/generalfields.md)
 * [Owner](entryeditor/owner.md)
 * [Quality and grading](../finding-sorting-and-cleaning-entries/specialfields.md)
 * [Time stamp](entryeditor/timestamp.md)

--- a/en/cite/openofficeintegration.md
+++ b/en/cite/openofficeintegration.md
@@ -26,9 +26,14 @@ Two different types of citations can be inserted - either a citation in parenthe
 
 If you modify entries in JabRef after inserting their citations into OpenOffice, you will need to synchronize the bibliography. By default, **Automatically sync bibliography when inserting citations** is enabled. This can be disabled by clicking the **Settings** button and unchecking **Automatically sync bibliography when inserting citations**. The **Sync OO bibliography** button will update all entries of the bibliography, provided their citation keys have not been altered (JabRef encodes the citation key into the reference name for each citation to keep track of which citation key the original JabRef entry has).
 
+The **Settings** menu also offers:
+
+* **Add space before citation** / **Add space after citation** — insert a space before and/or after each inserted citation marker if one isn't already there.
+* **Zotero compatibility mode** — when using a CSL style (not a legacy JStyle), makes JabRef emit citations in a form that Zotero can also read, and lets JabRef read citations that Zotero inserted.
+
 ## The style file
 
-To customize the citation style you need to select a style file, or use one of the default styles. The style defines the format of citations and the format of the bibliography. You can use standard JabRef export formatters to process fields before they are sent to OpenOffice. Through the style file, the intention is to give as much flexibility in citation styles as possible. You can switch style files at any time, and use the **Update** button to refresh your bibliography to follow the new style.
+To customize the citation style you need to select a style file, or use one of the default styles. In addition to JabRef's own JStyle format described below, you can also select a CSL style or, experimentally, a BibTeX `.bst` style file for the bibliography. The style defines the format of citations and the format of the bibliography. You can use standard JabRef export formatters to process fields before they are sent to OpenOffice. Through the style file, the intention is to give as much flexibility in citation styles as possible. You can switch style files at any time, and use the **Update** button to refresh your bibliography to follow the new style.
 
 By clicking the **Select style** button you can bring up a window that allows selection of either the default style or an external style file. If you want to create a new style based on the default, you can click the **View** button to bring up the default style contents, which can be copied into a text editor and modified.
 

--- a/en/collect/import-using-online-bibliographic-database.md
+++ b/en/collect/import-using-online-bibliographic-database.md
@@ -68,6 +68,10 @@ The [Bibliotheksverbund Bayern (BVB)](https://www.bib-bvb.de) provides bibliogra
 
 ### CiteSeerX
 
+{% hint style="warning" %}
+The CiteSeerX fetcher was removed from JabRef because the service is defunct and its links now redirect to the Wayback Machine.
+{% endhint %}
+
 [CiteSeerX](https://csxstatic.ist.psu.edu/home) is a public search engine for scientific and academic papers primarily with a focus on computer and information science. However, CiteSeerX has been expanding into other scholarly domains such as economics, physics, and others ([Wikipedia](https://en.wikipedia.org/wiki/CiteSeer)).
 
 ### Collection of Computer Science Bibliographies (CCSB)

--- a/en/faq/README.md
+++ b/en/faq/README.md
@@ -70,7 +70,7 @@ A: There are several reasons why JabRef cannot find your identifier online. For 
 
 ## Q: I miss a field _translator_, _lastfollowedon_, etc. How can I add such fields?
 
-A: To add this _translator_ field to all entry types, you can use **File → Preferences → Custom editor tabs** and add a _translator_ field under one of JabRef's general field tabs (see [Customize general field](../setup/generalfields.md)s). To add this _translator_ field to a specific entry type, edit the specific entry type(s) (**File → Customize entry types**) and add a _translator_ field under required fields or optional fields, as you like (see [Customize entry types](../setup/customentrytypes.md)).
+A: To add this _translator_ field to a specific entry type, edit the specific entry type(s) (**File → Customize entry types**) and add a _translator_ field under required fields or optional fields, as you like (see [Customize entry types](../setup/customentrytypes.md)). It will then show up in the entry editor's Main tab as a free field for entries of that type. Alternatively, you can add it as an arbitrary field to a single entry directly in the Main tab's free-form field box, without customizing the entry type.
 
 ## Q: How do I prevent JabRef from introducing line breaks in certain fields (such as “title”) when saving the .bib file?
 

--- a/en/finding-sorting-and-cleaning-entries/filelinks.md
+++ b/en/finding-sorting-and-cleaning-entries/filelinks.md
@@ -6,7 +6,7 @@ In BibTeX/biblatex terms, the file links are stored as text in the field `file`.
 
 ## Adding external links to an entry
 
-If the "file" field is included in [General fields](../setup/generalfields.md), you can edit the list of external links for an entry in the [Entry editor](../advanced/entryeditor/). The editor includes buttons for inserting, editing and removing links, as well as buttons for reordering the list of links.
+The "file" field is shown in the **Files and links** section of the [Entry editor](../advanced/entryeditor/)'s Main tab, where you can edit the list of external links for an entry. The editor includes buttons for inserting, editing and removing links, as well as buttons for reordering the list of links.
 
 ![](../.gitbook/assets/jabref-entryeditor-files.png)
 
@@ -31,7 +31,7 @@ In some settings, the bib file is stored in **the same directory** as the PDF fi
 
 ![Search and store files relative to library file location](../.gitbook/assets/preferences-file-searchandstoreforfilesrelativetolibraryfilelocation.png).
 
-Relative file directories obviously only work in the library properties for a bib file, e.g. `a.bib` Library → Library properties → Library-specific file directory → `papers`. Assume to have two bib files: `a.bib` and `b.bib` located in different directories: `a.bib` located at `C:\a.bib` and `b.bib` located at `X:\b.bib`. When I click on the `+` icon in the general Tab of file `a.bib`, the popup is opened in the directory `C:\papers` (assuming `C:\papers` exists).
+Relative file directories obviously only work in the library properties for a bib file, e.g. `a.bib` Library → Library properties → Library-specific file directory → `papers`. Assume to have two bib files: `a.bib` and `b.bib` located in different directories: `a.bib` located at `C:\a.bib` and `b.bib` located at `X:\b.bib`. When I click on the `+` icon in the Files and links section of file `a.bib`, the popup is opened in the directory `C:\papers` (assuming `C:\papers` exists).
 
 ## Auto-linking files
 

--- a/en/finding-sorting-and-cleaning-entries/getbibtexdatafromdoi.md
+++ b/en/finding-sorting-and-cleaning-entries/getbibtexdatafromdoi.md
@@ -3,7 +3,7 @@
 JabRef can fetch automatically additional information about your entries. It can even get the publication file!​
 
 * To _find identifiers_ (arxiv, DOI)\_: select the entries and go to the menu **Lookup → search document identifier online**.​
-* To _find the DOI_: open the [entry editor](../advanced/entryeditor/), and in the General tab, click on the button **Lookup DOI**.
+* To _find the DOI_: open the [entry editor](../advanced/entryeditor/), and in the Identifiers section of the Main tab, click on the button **Lookup DOI**.
 * To _find the document_ related to an entry: select the entry and to the menu [**Lookup → search full text documents online**](../collect/add-pdfs-to-an-entry.md).​
 
 Be aware: The options above require your entry or entries to be filled with enough and correct bibliographic information. If the entry holds incomplete or inaccurate data, fetching the identifier or text document my fail.
@@ -15,7 +15,7 @@ JabRef can help you complement your entries with bibliographic data, which is as
 _The following features require your entry to have a DOI or ISBN and are disabled / greyed out otherwise._
 
 * Option A) In the entry table, right-click on the entry to complement, and select the menu **Get bibliographic data from DOI/ISBN/...**
-* Option B) Open the [entry editor](../advanced/entryeditor/), and in the General tab, click on the button **Get bibliographic data from DOI**
+* Option B) Open the [entry editor](../advanced/entryeditor/), and in the Identifiers section of the Main tab, click on the button **Get bibliographic data from DOI**
 
 ![](../.gitbook/assets/getdoi-entryeditor-jabref5.2.png)
 

--- a/en/finding-sorting-and-cleaning-entries/keywords.md
+++ b/en/finding-sorting-and-cleaning-entries/keywords.md
@@ -6,12 +6,16 @@ description: Keywords help you in organizing, sorting and searching your entries
 
 ## The field "keywords"
 
-Keywords can be added to your entries in a specific field. In the entry editor, the keywords field is displayed in the General tab. There, you can add new keywords to an entry by typing it in. If auto-completion is activated for the field keywords (**File → Preferences → Entry editor**), suggestions are given based on existing keywords.
+Keywords can be added to your entries in a specific field. In the entry editor, the keywords field is displayed in the Main tab. There, you can add new keywords to an entry by typing it in. If auto-completion is activated for the field keywords (**File → Preferences → Entry editor**), suggestions are given based on existing keywords.
 
 By default, the keyword separator is a comma. It can be redefined in the preferences (**File → Preferences → Entry**). To use the separator character within a keyword itself, you can escape it with a backslash (`\`).
 
 {% hint style="info" %}
-If some entries have a keyword separator differing from the prescribed one, you can use menu **Edit → Find and replace**. For example, you may want to replace semi-columns (;) by commas (,). Select the radio button "Limit to Fields" and type in "keywords" as the relevant field.​​
+When importing BibTeX entries, JabRef automatically detects keyword delimiters (such as `;`) that differ from your configured separator and normalizes them on import.
+{% endhint %}
+
+{% hint style="info" %}
+If entries already in your library have a keyword separator differing from the prescribed one, you can use menu **Edit → Find and replace**. For example, you may want to replace semi-columns (;) by commas (,). Select the radio button "Limit to Fields" and type in "keywords" as the relevant field.​​
 {% endhint %}
 
 Additionally, the [special field](specialfields.md) values (relevance, priority, etc.) can be added to the keywords field automatically. This will allow you to group, sort, and search your library based on the special field values. See in **File → Preferences → Entry table** the item "Special fields" and select "Synchronize with keywords".

--- a/en/getting-started.md
+++ b/en/getting-started.md
@@ -57,7 +57,7 @@ After clicking on the "Article" button, the dialog closes and the so called "Ent
 
 ![Main window now showing the entry editor](.gitbook/assets/getting-started-entry-editor.png)
 
-The most important information about the references to be added can now be entered in the "Required Fields" tab. "Author", "Title", "Journal", and "Year" should be self-explanatory - however, a "citationkey", might not be familiar to you. Basically, the idea of the "citationkey" is coming from working with BibTeX, where it is necessary to have an unique identifier for each entry. This allows for referencing within a document you might be creating using the stored information in your library. Moreover, also within JabRef this "key" is used for example for cross-references to other related entries or to determine file names for full-text references.
+The most important information about the reference to be added can now be entered in the "Main" tab. "Author", "Title", "Journal", and "Year" should be self-explanatory - however, a "citationkey", might not be familiar to you. Basically, the idea of the "citationkey" is coming from working with BibTeX, where it is necessary to have an unique identifier for each entry. This allows for referencing within a document you might be creating using the stored information in your library. Moreover, also within JabRef this "key" is used for example for cross-references to other related entries or to determine file names for full-text references.
 
 The key usually follows a global pattern and can be easily created automatically by clicking on the "generate" button next to the field.
 

--- a/en/setup/generalfields.md
+++ b/en/setup/generalfields.md
@@ -1,17 +1,10 @@
-# Customize general fields
+# Entry editor tabs
 
-You can add an arbitrary number of tabs to the entry editor. These will be present for all entry types. To customize these tabs, go to **File → Preferences → Entry Editor → Custom editor tabs**.
+{% hint style="info" %}
+Since the entry editor's redesign, it is no longer possible to define custom tabs with an arbitrary set of fields. All fields of an entry are shown together in the entry editor's [Main tab](../advanced/entryeditor/#the-main-tab), grouped into collapsible sections (Identifiers, Files and links, Bibliometrics, Comments, Meta). The rest of this page describes the tabs that remain configurable.
+{% endhint %}
 
-You specify one tab on each line. The line should start with the name of the tab, followed by a colon \(:\), and the fields it should contain, separated by semicolons \(;\).
+You can choose which of the entry editor's built-in tabs are shown, and in which order, under **File → Preferences → Entry Editor → Editor tabs**. Untick a tab to hide it for all entry types; the tab list includes the Main tab, Bib(la)TeX source, Related articles, AI summary, AI chat, File annotations, LaTeX citations, Citations and Fulltext search results.
 
-For example:
-
-```csv
-General:url;keywords;doi;pdf
-Abstract:abstract;annote
-```
-
-will give one tab named "General" containing the fields _url_, _keywords_, _doi_ and _pdf_, and another tab named "Abstract" containing the fields _abstract_ and _annote_.
-
-It does not matter how you capitalise your field names. In the entry editor's tabs, normally fields' first letter is capitalised, i.e. _abstract_ is represented as _Abstract_, _KEYwords_ would be represented as _Keywords_  (_DOI_, _ISBN_, _URL_ are exceptions in that all letters are capitalised). In the bibtex code, all field names use lower case: _KEYwords_ is _keywords_ in the entry's bibtex code.
+It does not matter how a field's name is capitalised. In the entry editor, normally a field's first letter is capitalised, i.e. _abstract_ is represented as _Abstract_, _KEYwords_ would be represented as _Keywords_ (_DOI_, _ISBN_, _URL_ are exceptions in that all letters are capitalised). In the bibtex code, all field names use lower case: _KEYwords_ is _keywords_ in the entry's bibtex code.
 


### PR DESCRIPTION
## Summary

This is a **low-risk, documentation-only update** (no code changes) generated by an automated monthly review that cross-references `jabref/jabref` commits from the last month against these docs. It only touches pages where I found concrete evidence of a doc/behavior mismatch — nothing here is speculative.

By far the biggest driver is the entry editor redesign in [jabref/jabref#16166](https://github.com/JabRef/jabref/pull/16166) ("New entry editor", closes [jabref/jabref#12711](https://github.com/JabRef/jabref/issues/12711), merged 2026-07-05), which:
- Removed the "Required fields", "Optional fields", "General", "Abstract", and "Comments" entry-editor tabs, replacing them with a single scrollable **Main** tab that groups fields into collapsible sections (Identifiers, Files and links, Bibliometrics, Comments, Meta).
- Removed the ability to define custom entry-editor tabs (the whole `setup/generalfields.md` "Custom editor tabs" feature no longer exists).

I verified the new field→section mapping directly against `FieldListSections.java` in the jabref repo (e.g. DOI/ISBN/PMID/MR Number → Identifiers, citation count/ICORE → Bibliometrics, owner/timestamps/groups → Meta) rather than guessing, so the section names cited below should be accurate even though I couldn't regenerate the (now outdated) screenshots.

## Changes and what motivated them

**Entry editor redesign** ([jabref/jabref#16166](https://github.com/JabRef/jabref/pull/16166) / issue [#12711](https://github.com/JabRef/jabref/issues/12711), 2026-07-05):
- `en/advanced/entryeditor/README.md` — rewrote "The entry editor's panels" section to describe the new Main tab and its sections, and the current full list of built-in tabs (verified against `EntryEditorTabModel.BuiltIn`); added a short "Jump to field" section for the new Ctrl+J shortcut ([jabref/jabref#16169](https://github.com/JabRef/jabref/pull/16169), 2026-07-05).
- `en/setup/generalfields.md` — replaced the "Custom editor tabs" instructions (feature removed) with a description of the current "Editor tabs" show/hide preference; retitled to "Entry editor tabs" (updated the link text in `en/SUMMARY.md` and `en/advanced/fields.md` to match).
- `en/advanced/entryeditor/owner.md`, `en/advanced/entryeditor/timestamp.md`, `en/advanced/entryeditor/icore-field.md`, `en/advanced/entryeditor/entrylinks.md` — updated "General fields tab" / "General tab" / "Other fields" references to the correct new section (Meta, Bibliometrics, Main), per the verified field→section mapping.
- `en/faq/README.md`, `en/finding-sorting-and-cleaning-entries/keywords.md`, `en/finding-sorting-and-cleaning-entries/getbibtexdatafromdoi.md`, `en/finding-sorting-and-cleaning-entries/filelinks.md`, `en/getting-started.md` — same "General tab" → correct Main-tab-section fix, for the DOI lookup buttons, keywords field, file field, and the new-user walkthrough.

**LibreOffice/OpenOffice integration** ([jabref/jabref#16372](https://github.com/JabRef/jabref/pull/16372) "add space before citation", 2026-07-27; Zotero compatibility mode work merged through 2026-07-28; [jabref/jabref#16315](https://github.com/JabRef/jabref/pull/16315) "Support BST styles in LibreOffice", 2026-07-25):
- `en/cite/openofficeintegration.md` — documented the new "Add space before citation" and "Zotero compatibility mode" Settings-menu entries, and noted that CSL and (experimental) `.bst` styles are selectable alongside JStyle.

**Automatic keyword-delimiter detection on import** ([jabref/jabref#15521](https://github.com/JabRef/jabref/pull/15521), 2026-07-28):
- `en/finding-sorting-and-cleaning-entries/keywords.md` — added a note that JabRef now auto-detects and normalizes differing keyword delimiters on BibTeX import.

**CiteSeerX fetcher removed** ([jabref/jabref#16316](https://github.com/JabRef/jabref/pull/16316), 2026-07-23, because the service is defunct):
- `en/collect/import-using-online-bibliographic-database.md` — added a warning hint (mirroring the existing pattern used for the defunct CCSB catalog).
- `en/README.md` — dropped CiteSeer from the list of searchable catalogs on the front page.

## What I checked but did *not* change

I cross-referenced `CHANGELOG.md` "Unreleased" entries against the jabref commit history (`git blame`/commit dates) to confirm each item actually landed in the last month, not just that its changelog line was recently reformatted — e.g. I ruled out the "AI response engines" refactor (actually merged mid-May) and the `jabkit check` command grouping (actually merged in May/December, pre-existing doc staleness unrelated to this window). I also left `jabkit.md`, the HTTP import endpoint, and the new Hayagriva YAML importer undocumented since there's no existing baseline page to correct without speculating about UI/format details I couldn't verify against source.

## Review

Given the low risk (docs only, each change backed by a cited jabref commit/PR), a quick review/merge would be appreciated. Happy to adjust wording or scope down if any of these reads as too speculative.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YNdLv2HDFpnZXHaMGc9aRY)_