### PR TITLE
Update custom themes page for new theme/color scheme model

### DIFF
--- a/en/advanced/custom-themes.md
+++ b/en/advanced/custom-themes.md
@@ -2,19 +2,19 @@
 
 ## General
 
-The look of JabRef is defined by [CSS](https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/CSS_basics) files. In `Preferences > General > Appearance` you choose three things:
+[CSS](https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/CSS_basics) files define the look of JabRef. In `Preferences > General > Appearance` you choose three things:
 
 * **Theme**: the base look, currently _JabRef theme_ ([`jabref-theme.css`](https://github.com/JabRef/jabref/blob/first-class-theme-support/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css)) or _Primer theme_ ([`primer-theme.css`](https://github.com/JabRef/jabref/blob/first-class-theme-support/jabgui/src/main/resources/org/jabref/gui/theme/primer-theme.css), based on [AtlantaFX](https://mkpaz.github.io/atlantafx/)). Every theme comes with a light and a dark variant.
 * **Color scheme**: _Follow system_, _Light_, or _Dark_.
-* **Custom theme**: an additional CSS file of your own. It is applied _on top_ of the selected theme and color scheme, so it only needs to contain what you want to change.
+* **Custom theme**: a CSS file of your own. JabRef applies it _on top_ of the selected theme and color scheme, so it only needs to contain what you want to change.
 
-Changes to the custom CSS file are picked up while JabRef is running, so you can edit the file and see the result immediately.
+JabRef picks up changes to the custom CSS file while it is running, so you can edit the file and see the result immediately.
 
 You can find a collection of user contributed themes at [https://themes.jabref.org](https://themes.jabref.org/).
 
 ## Writing a custom theme
 
-All colors of a theme are defined as `-color-*` variables (for example `-color-accent`, `-color-bg-primary`, `-color-fg-default`, `-color-selection`). The full list is in [`jabref-theme.css`](https://github.com/JabRef/jabref/blob/first-class-theme-support/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css); the rest of JabRef's styling only uses these variables, so overriding them is enough to re-color the whole UI.
+A theme defines all its colors as `-color-*` variables (for example `-color-accent`, `-color-bg-primary`, `-color-fg-default`, `-color-selection`). The full list is in [`jabref-theme.css`](https://github.com/JabRef/jabref/blob/first-class-theme-support/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css); the rest of JabRef's styling only uses these variables, so overriding them is enough to re-color the whole UI.
 
 Override a variable for both color schemes:
 
@@ -35,7 +35,7 @@ Override it for one color scheme only. The media query follows the color scheme 
 ```
 
 {% hint style="info" %}
-Custom themes written for JabRef 6.x and earlier used `-jr-*` variables (such as `-jr-theme` or `-jr-accent`). These no longer exist and are ignored; replace them by the corresponding `-color-*` variables.
+Custom themes written for JabRef 6.x and earlier used `-jr-*` variables (such as `-jr-theme` or `-jr-accent`). These no longer exist and JabRef ignores them; replace them by the corresponding `-color-*` variables.
 {% endhint %}
 
 ## Selection of Useful CSS selectors

--- a/en/advanced/custom-themes.md
+++ b/en/advanced/custom-themes.md
@@ -8,7 +8,7 @@
 * **Color scheme**: _Follow system_, _Light_, or _Dark_.
 * **Custom theme**: a CSS file of your own. JabRef applies it _on top_ of the selected theme and color scheme, so it only needs to contain what you want to change.
 
-JabRef picks up changes to the custom CSS file while it is running, so you can edit the file and see the result immediately.
+JabRef picks up changes to the custom CSS file while running, so you can edit the file and see the result immediately.
 
 You can find a collection of user contributed themes at [https://themes.jabref.org](https://themes.jabref.org/).
 

--- a/en/advanced/custom-themes.md
+++ b/en/advanced/custom-themes.md
@@ -4,7 +4,7 @@
 
 [CSS](https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/CSS_basics) files define the look of JabRef. In `Preferences > General > Appearance` you choose three things:
 
-* **Theme**: the base look, currently _JabRef theme_ ([`jabref-theme.css`](https://github.com/JabRef/jabref/blob/first-class-theme-support/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css)) or _Primer theme_ ([`primer-theme.css`](https://github.com/JabRef/jabref/blob/first-class-theme-support/jabgui/src/main/resources/org/jabref/gui/theme/primer-theme.css), based on [AtlantaFX](https://mkpaz.github.io/atlantafx/)). Every theme comes with a light and a dark variant.
+* **Theme**: the base look, currently _JabRef theme_ ([`jabref-theme.css`](https://github.com/JabRef/jabref/blob/main/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css)) or _Primer theme_ ([`primer-theme.css`](https://github.com/JabRef/jabref/blob/main/jabgui/src/main/resources/org/jabref/gui/theme/primer-theme.css), based on [AtlantaFX](https://mkpaz.github.io/atlantafx/)). Every theme comes with a light and a dark variant.
 * **Color scheme**: _Follow system_, _Light_, or _Dark_.
 * **Custom theme**: a CSS file of your own. JabRef applies it _on top_ of the selected theme and color scheme, so it only needs to contain what you want to change.
 
@@ -14,7 +14,7 @@ You can find a collection of user contributed themes at [https://themes.jabref.o
 
 ## Writing a custom theme
 
-A theme defines all its colors as `-color-*` variables (for example `-color-accent`, `-color-bg-primary`, `-color-fg-default`, `-color-selection`). The full list is in [`jabref-theme.css`](https://github.com/JabRef/jabref/blob/first-class-theme-support/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css); the rest of JabRef's styling only uses these variables, so overriding them is enough to re-color the whole UI.
+A theme defines all its colors as `-color-*` variables (for example `-color-accent`, `-color-bg-primary`, `-color-fg-default`, `-color-selection`). The full list is in [`jabref-theme.css`](https://github.com/JabRef/jabref/blob/main/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css); the rest of JabRef's styling only uses these variables, so overriding them is enough to re-color the whole UI.
 
 Override a variable for both color schemes:
 

--- a/en/advanced/custom-themes.md
+++ b/en/advanced/custom-themes.md
@@ -2,15 +2,41 @@
 
 ## General
 
-Since `JabRef 5.2` it is possible to use custom themes. In `Preferences > Appearance > Visual theme` the themes in general can be changed. Themes are just [CSS](https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/CSS_basics) files defining the look of the UI.
+The look of JabRef is defined by [CSS](https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/CSS_basics) files. In `Preferences > General > Appearance` you choose three things:
 
-* **Light Theme**: The default theme is the light theme ([`Base.css`](https://github.com/JabRef/jabref/blob/main/src/main/java/org/jabref/gui/Base.css)).
-* **Dark Theme**: There is an alternative dark theme ([`Dark.css`](https://github.com/JabRef/jabref/blob/main/src/main/java/org/jabref/gui/Dark.css)) which is based on `Base.css` and just overwrites the colors.
-* **Custom Theme**: In `Preferences > Appearance > Visual theme > Custom theme` there can be set a custom theme by simply selecting a custom CSS (based on `Base.css` or `Dark.css`), for instance:
+* **Theme**: the base look, currently _JabRef theme_ ([`jabref-theme.css`](https://github.com/JabRef/jabref/blob/main/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css)) or _Primer theme_ ([`primer-theme.css`](https://github.com/JabRef/jabref/blob/main/jabgui/src/main/resources/org/jabref/gui/theme/primer-theme.css), based on [AtlantaFX](https://mkpaz.github.io/atlantafx/)). Every theme comes with a light and a dark variant.
+* **Color scheme**: _Follow system_, _Light_, or _Dark_.
+* **Custom theme**: an additional CSS file of your own. It is applied _on top_ of the selected theme and color scheme, so it only needs to contain what you want to change.
+
+Changes to the custom CSS file are picked up while JabRef is running, so you can edit the file and see the result immediately.
 
 You can find a collection of user contributed themes at [https://themes.jabref.org](https://themes.jabref.org/).
 
-{% file src="../.gitbook/assets/dark-custom.css" %}
+## Writing a custom theme
+
+All colors of a theme are defined as `-color-*` variables (for example `-color-accent`, `-color-bg-primary`, `-color-fg-default`, `-color-selection`). The full list is in [`jabref-theme.css`](https://github.com/JabRef/jabref/blob/main/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css); the rest of JabRef's styling only uses these variables, so overriding them is enough to re-color the whole UI.
+
+Override a variable for both color schemes:
+
+```css
+.root {
+    -color-accent: #8F0D11;
+}
+```
+
+Override it for one color scheme only. The media query follows the color scheme selected in JabRef (or the operating system, with _Follow system_):
+
+```css
+@media (prefers-color-scheme: dark) {
+    .root {
+        -color-accent: #ff79c6;
+    }
+}
+```
+
+{% hint style="info" %}
+Custom themes written for JabRef 6.x and earlier used `-jr-*` variables (such as `-jr-theme` or `-jr-accent`). These no longer exist and are ignored; replace them by the corresponding `-color-*` variables.
+{% endhint %}
 
 ## Selection of Useful CSS selectors
 
@@ -19,14 +45,6 @@ You can find a collection of user contributed themes at [https://themes.jabref.o
 | preview box                      | `#previewBody`     |
 | `{} biblatex source` tab         | `.code-area`       |
 | text in `{} biblatex source` tab | `.code-area .text` |
-
-## Examples
-
-**Light Theme** ![Light Theme](../.gitbook/assets/theme-light.png)
-
-**Dark Theme** ![Dark Theme](../.gitbook/assets/theme-dark.png)
-
-**Custom Theme** ![Custom Theme](../.gitbook/assets/theme-custom.png) (based on the Dark Theme)
 
 ## Known bugs
 

--- a/en/advanced/custom-themes.md
+++ b/en/advanced/custom-themes.md
@@ -4,7 +4,7 @@
 
 The look of JabRef is defined by [CSS](https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/CSS_basics) files. In `Preferences > General > Appearance` you choose three things:
 
-* **Theme**: the base look, currently _JabRef theme_ ([`jabref-theme.css`](https://github.com/JabRef/jabref/blob/main/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css)) or _Primer theme_ ([`primer-theme.css`](https://github.com/JabRef/jabref/blob/main/jabgui/src/main/resources/org/jabref/gui/theme/primer-theme.css), based on [AtlantaFX](https://mkpaz.github.io/atlantafx/)). Every theme comes with a light and a dark variant.
+* **Theme**: the base look, currently _JabRef theme_ ([`jabref-theme.css`](https://github.com/JabRef/jabref/blob/first-class-theme-support/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css)) or _Primer theme_ ([`primer-theme.css`](https://github.com/JabRef/jabref/blob/first-class-theme-support/jabgui/src/main/resources/org/jabref/gui/theme/primer-theme.css), based on [AtlantaFX](https://mkpaz.github.io/atlantafx/)). Every theme comes with a light and a dark variant.
 * **Color scheme**: _Follow system_, _Light_, or _Dark_.
 * **Custom theme**: an additional CSS file of your own. It is applied _on top_ of the selected theme and color scheme, so it only needs to contain what you want to change.
 
@@ -14,7 +14,7 @@ You can find a collection of user contributed themes at [https://themes.jabref.o
 
 ## Writing a custom theme
 
-All colors of a theme are defined as `-color-*` variables (for example `-color-accent`, `-color-bg-primary`, `-color-fg-default`, `-color-selection`). The full list is in [`jabref-theme.css`](https://github.com/JabRef/jabref/blob/main/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css); the rest of JabRef's styling only uses these variables, so overriding them is enough to re-color the whole UI.
+All colors of a theme are defined as `-color-*` variables (for example `-color-accent`, `-color-bg-primary`, `-color-fg-default`, `-color-selection`). The full list is in [`jabref-theme.css`](https://github.com/JabRef/jabref/blob/first-class-theme-support/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css); the rest of JabRef's styling only uses these variables, so overriding them is enough to re-color the whole UI.
 
 Override a variable for both color schemes:
 

--- a/en/faq/windows.md
+++ b/en/faq/windows.md
@@ -28,6 +28,6 @@ A: According to [source](https://discourse.jabref.org/t/chinese-character/4167),
 
 ```css
 .text {
--fx-font-family: “Microsoft YaHei”;
+-fx-font-family: "Microsoft YaHei";
 }
 ```

--- a/en/faq/windows.md
+++ b/en/faq/windows.md
@@ -24,7 +24,7 @@ A: On Windows, one finds the log files in `%APPDATA%\..\Local\org.jabref\jabref\
 
 ## Q: I have issues with the Chinese display language in Windows 10 Enterprise. What can I do?
 
-A: According to [source](https://discourse.jabref.org/t/chinese-character/4167), you may have to set the font manually by downloading the Base.css from Custom themes - JabRef. Then open the Base.css, and add the following text at the end of Base.css:
+A: According to [source](https://discourse.jabref.org/t/chinese-character/4167), you may have to set the font manually with a [custom theme](../advanced/custom-themes.md): create a CSS file with the following content and select it in `Preferences > General > Appearance > Custom theme`:
 
 ```css
 .text {


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Prepares the custom themes page for JabRef/jabref#15798: appearance preferences are now Theme + Color scheme + optional custom CSS on top, and theme colors are `-color-*` variables (the old `-jr-*` ones are gone). Also drops the stale `Base.css` download advice from the Windows font FAQ.

Low-risk documentation update. Should be merged together with (or after) JabRef/jabref#15798.



The theme CSS links point at the `first-class-theme-support` branch so the link checker passes; switch them to `main` once JabRef/jabref#15798 is merged.
