### PR TITLE
Describe the external changes review dialog

### DIFF
--- a/en/collaborative-work/sharedbibfile.md
+++ b/en/collaborative-work/sharedbibfile.md
@@ -12,3 +12,14 @@ To make the sharing of a Bib\(la\)TeX library easier, it is recommended to set s
 * Define a sort order \(`year`, `author`, `title` is recommended\)..
 * Check `Enable save formatters`, and defines these actions, to help enforcing a consistent format for the entries.
 
+
+## Reviewing external changes
+
+When the `bib` file changes on disk while it is open, JabRef shows a notification "External changes detected" with two actions:
+
+* **Dismiss changes** closes the notification. The next save overwrites the file with the in-memory library.
+* **Review changes** opens the External Changes Resolver, listing every difference between the file on disk and the library in memory. Select a change and choose **Accept** (take the version from disk), **Deny** (keep the in-memory version), or **Merge...** (for modified entries: combine both versions field by field).
+
+The dialog closes automatically once every change is resolved, and the decisions are applied to the library. If all changes were accepted, the library matches the file on disk and is not marked as changed; otherwise it is marked as changed and needs to be saved.
+
+Closing the dialog before all changes are resolved applies nothing: the library stays as it was, and the notification remains so the review can be resumed later.


### PR DESCRIPTION
The sharing page did not describe what happens after JabRef detects external changes. This adds a short section on the notification and the External Changes Resolver (accept / deny / merge, and that cancelling the dialog applies nothing and keeps the notification).

The cancel behaviour matches JabRef/jabref#16698, so this should be merged together with (or after) that PR.

Low-risk documentation update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
