### PR TITLE
Mention orange highlight for auto-linkable files

### DIFF
--- a/en/finding-sorting-and-cleaning-entries/filelinks.md
+++ b/en/finding-sorting-and-cleaning-entries/filelinks.md
@@ -35,7 +35,7 @@ Relative file directories obviously only work in the library properties for a bi
 
 ## Auto-linking files
 
-If you have a file within or below one of your file directories with an extension matching one of the defined external file types, and a name starting with (or matching) an entry's citation key, the file can be auto-linked. JabRef will detect the file and display it in the entry editor with an orange background and a "link-add" icon at the left of the filename. Click on the "link-add" icon to link this file to the entry.
+If you have a file within or below one of your file directories with an extension matching one of the defined external file types, and a name starting with (or matching) an entry's citation key, the file can be auto-linked. JabRef will detect the file and display it in the entry editor with a gray background and a "link-add" icon at the left of the filename. Click on the "link-add" icon to link this file to the entry.
 
 The rules for which file names can be auto-linked to a citation key can be set up in **File → Preferences → Linked files**, section _Autolink files_.
 

--- a/en/finding-sorting-and-cleaning-entries/filelinks.md
+++ b/en/finding-sorting-and-cleaning-entries/filelinks.md
@@ -35,7 +35,7 @@ Relative file directories obviously only work in the library properties for a bi
 
 ## Auto-linking files
 
-If you have a file within or below one of your file directories with an extension matching one of the defined external file types, and a name starting with (or matching) an entry's citation key, the file can be auto-linked. JabRef will detect the file and display a "link-add" icon in the entry editor, at the left of the filename. Click on the "link-add" icon to link this file to the entry.
+If you have a file within or below one of your file directories with an extension matching one of the defined external file types, and a name starting with (or matching) an entry's citation key, the file can be auto-linked. JabRef will detect the file and display it in the entry editor with an orange background and a "link-add" icon at the left of the filename. Click on the "link-add" icon to link this file to the entry.
 
 The rules for which file names can be auto-linked to a citation key can be set up in **File → Preferences → Linked files**, section _Autolink files_.
 


### PR DESCRIPTION
Auto-linkable files found in the file directory are shown again in the entry editor, now with a gray background (code change for issue github.com/JabRef/jabref/issues/16737, defanged link). This updates the auto-linking section accordingly.

Low-risk documentation update — a single sentence changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)