### PR TITLE
Reflect the regrouped entry context menu

### DIFF
--- a/en/finding-sorting-and-cleaning-entries/filelinks.md
+++ b/en/finding-sorting-and-cleaning-entries/filelinks.md
@@ -79,7 +79,7 @@ The default for searches is `**/.*[citationkey].*\\.[extension]`. As you can see
 
 ## Opening external files
 
-There are several ways to open an external file or web page. In the entry table, you can click on the PDF icon to open the PDF. In case there are multiple PDFs linked, always the first one is opened. You can also right-click on the line of the entry in the entry table and select "Open file". There is also a keyboard shortcut for this: In the default setting, this is `F4`, but [it can also be customized](../setup/customkeybindings.md).
+There are several ways to open an external file or web page. In the entry table, you can click on the PDF icon to open the PDF. In case there are multiple PDFs linked, always the first one is opened. You can also right-click on the line of the entry in the entry table and select "More file operations..." > "Open file". There is also a keyboard shortcut for this: In the default setting, this is `F4`, but [it can also be customized](../setup/customkeybindings.md).
 
 To access any of an entry's links, click on the icon with the right mouse button (or `Ctrl + Click` on Mac OS X) to bring up a menu showing all links.
 

--- a/en/getting-started.md
+++ b/en/getting-started.md
@@ -97,7 +97,7 @@ Usually, you also want to attach a reference to the full-text of a reference. Fo
 In order to use the automated feature, it is necessary to set-up a file directory first. To do so, please go to "Options" > "Preferences", go to "Linked files" section, and select there an existing folder as the "Main file directory":
 {% endhint %}
 
-To test the automatic download of full texts you can click on the "Get full-text" icon next to the file field, or choose "Lookup" -> "Search full text documents online" from the menu. As soon as a full-text is found, the file will be stored in the local file directory and linked to the entry:
+To test the automatic download of full texts you can click on the "Get full-text" icon next to the file field, or choose "Lookup" -> "Search full text documents online" from the menu, or "Get fulltext" from the entry's right-click menu. As soon as a full-text is found, the file will be stored in the local file directory and linked to the entry:
 
 ![Finding a full-text document online](.gitbook/assets/getting-started-entry-editor-full-text.png)
 


### PR DESCRIPTION
🤖 The entry context menu in JabRef now offers "Get fulltext" directly and groups the file commands under "More file operations..."; the two places that name those menu entries are updated. Low-risk documentation update.

Accompanies github.com/JabRef/jabref/pull/16829

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mkXzbUjnC9crn8w8d9neF