### PR TITLE
Document per-library keyword separator

### DIFF
--- a/en/finding-sorting-and-cleaning-entries/keywords.md
+++ b/en/finding-sorting-and-cleaning-entries/keywords.md
@@ -8,10 +8,10 @@ description: Keywords help you in organizing, sorting and searching your entries
 
 Keywords can be added to your entries in a specific field. In the entry editor, the keywords field is displayed in the Main tab. There, you can add new keywords to an entry by typing it in. If auto-completion is activated for the field keywords (**File → Preferences → Entry editor**), suggestions are given based on existing keywords.
 
-By default, the keyword separator is a comma. It can be redefined in the preferences (**File → Preferences → Entry**). To use the separator character within a keyword itself, you can escape it with a backslash (`\`).
+By default, the keyword separator is a comma. It can be redefined globally in the preferences (**File → Preferences → Entry**) and per library in the [library properties](../setup/databaseproperties.md#keyword-separator) (**Library → Library properties → General**). A separator set in the library properties takes precedence over the global preference. To use the separator character within a keyword itself, you can escape it with a backslash (`\`).
 
 {% hint style="info" %}
-When importing BibTeX entries, JabRef automatically detects keyword delimiters (such as `;`) that differ from your configured separator and normalizes them on import.
+When opening a library that does not declare a separator, JabRef keeps the separator its keyword fields already use (for example `;`) instead of rewriting them to the global preference. Keyword fields that use a different delimiter than the library's separator are normalized on import.
 {% endhint %}
 
 {% hint style="info" %}

--- a/en/finding-sorting-and-cleaning-entries/keywords.md
+++ b/en/finding-sorting-and-cleaning-entries/keywords.md
@@ -8,14 +8,14 @@ description: Keywords help you in organizing, sorting and searching your entries
 
 Keywords can be added to your entries in a specific field. In the entry editor, the keywords field is displayed in the Main tab. There, you can add new keywords to an entry by typing it in. If auto-completion is activated for the field keywords (**File → Preferences → Entry editor**), suggestions are given based on existing keywords.
 
-By default, the keyword separator is a comma. It can be redefined globally in the preferences (**File → Preferences → Entry**) and per library in the [library properties](../setup/databaseproperties.md#keyword-separator) (**Library → Library properties → General**). A separator set in the library properties takes precedence over the global preference. To use the separator character within a keyword itself, you can escape it with a backslash (`\`).
+By default, the keyword separator is a comma. You can redefine it globally in the preferences (**File → Preferences → Entry**) and per library in the [library properties](../setup/databaseproperties.md#keyword-separator) (**Library → Library properties → General**). A separator set in the library properties takes precedence over the global preference. To use the separator character within a keyword itself, you can escape it with a backslash (`\`).
 
 {% hint style="info" %}
-When opening a library that does not declare a separator, JabRef keeps the separator its keyword fields already use (for example `;`) instead of rewriting them to the global preference. Keyword fields that use a different delimiter than the library's separator are normalized on import.
+When opening a library that does not declare a separator, JabRef keeps the separator its keyword fields already use (for example `;`) instead of rewriting them to the global preference. On import, JabRef rewrites keyword fields that use a different delimiter to the library's separator.
 {% endhint %}
 
 {% hint style="info" %}
-If entries already in your library have a keyword separator differing from the prescribed one, use the cleanup "Normalize keyword delimiters" (**Quality → Cleanup entries**, section "Field formatters"). It rewrites the keywords of the selected entries to the library's keyword separator. The cleanup is also part of the default save actions (**Library → Library properties → Saving**), so entries you edit are normalized when the library is saved.
+If entries already in your library have a keyword separator differing from the prescribed one, use the cleanup "Normalize keyword delimiters" (**Quality → Cleanup entries**, section "Field formatters"). It rewrites the keywords of the selected entries to the library's keyword separator. The cleanup is also part of the default save actions (**Library → Library properties → Saving**), so JabRef normalizes the entries you edit when you save the library.
 {% endhint %}
 
 Additionally, the [special field](specialfields.md) values (relevance, priority, etc.) can be added to the keywords field automatically. This will allow you to group, sort, and search your library based on the special field values. See in **File → Preferences → Entry table** the item "Special fields" and select "Synchronize with keywords".

--- a/en/finding-sorting-and-cleaning-entries/keywords.md
+++ b/en/finding-sorting-and-cleaning-entries/keywords.md
@@ -15,7 +15,7 @@ When opening a library that does not declare a separator, JabRef keeps the separ
 {% endhint %}
 
 {% hint style="info" %}
-If entries already in your library have a keyword separator differing from the prescribed one, you can use menu **Edit → Find and replace**. For example, you may want to replace semi-columns (;) by commas (,). Select the radio button "Limit to Fields" and type in "keywords" as the relevant field.​​
+If entries already in your library have a keyword separator differing from the prescribed one, use the cleanup "Normalize keyword delimiters" (**Quality → Cleanup entries**, section "Field formatters"). It rewrites the keywords of the selected entries to the library's keyword separator. The cleanup is also part of the default save actions (**Library → Library properties → Saving**), so entries you edit are normalized when the library is saved.
 {% endhint %}
 
 Additionally, the [special field](specialfields.md) values (relevance, priority, etc.) can be added to the keywords field automatically. This will allow you to group, sort, and search your library based on the special field values. See in **File → Preferences → Entry table** the item "Special fields" and select "Synchronize with keywords".

--- a/en/setup/databaseproperties.md
+++ b/en/setup/databaseproperties.md
@@ -38,6 +38,12 @@ UTF-8 is highly recommended
 
 You can select if your library follows the [BibTeX or the biblatex format](../cite/bibtex-and-biblatex.md).
 
+#### Keyword separator
+
+The character that separates keywords in the `keywords` field of this library, for example `,` or `;`. It overrides the keyword separator set in the Preferences dialog.
+
+When a library does not declare a separator, JabRef uses the one its keyword fields already use, so opening a library does not rewrite its keywords. If the keywords contain no separator at all, the global preference applies. Clear the field to remove the library-specific setting.
+
 ### Override default file directories
 
 In your library, files (PDF, etc.) can be linked to an entry. The list of these files are stored in the _file_ field of the entry. The location of these files has to be specified.


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Documents the new per-library keyword separator added in JabRef PR https://github.com/JabRef/jabref/pull/16835. Low-risk documentation update.
