### PR TITLE
Document shared database URLs as JabKit input

### DIFF
--- a/en/jabkit.md
+++ b/en/jabkit.md
@@ -87,6 +87,17 @@ Commands:
 
 Hint: Using `jabkit <COMMAND> --help` will show the supported options for each command.
 
+## Input sources
+
+Wherever a command takes an input file, you can also pass an `http(s)` or `ftp` URL, or the PostgreSQL connection URL of a [shared SQL library](collaborative-work/sqldatabase/README.md):
+
+```bash
+jabkit convert 'postgresql://user:secret@host:5432/library' --output refs.bib
+```
+
+The shared library is read once and not written back to; changes made by JabKit stay in the output file.
+Quote the URL so that your shell does not interpret the special characters in it, and be aware that the password becomes part of your shell history.
+
 ## Updating JabKit
 
 Make use of `--fresh` to update JabKit


### PR DESCRIPTION
# Pull Request Description

### Summary

Adds an "Input sources" section to the JabKit page: wherever a command takes an input file, a URL or the connection URL of a shared SQL library can be passed instead.

### Steps to test

Check the preview link in this PR, go to the JabKit page, section "Input sources", and follow the example against a shared SQL library.

### Related issues and pull requests

Documents JabRef/jabref#16970

### AI usage

Claude Code (model claude-opus-5), AIL3: text written by the AI; reviewed by me.

### Checklist

- [x] I reviewed and take ownership of all content in this PR, including any AI-assisted text
- [x] I opened JabRef and followed these instructions myself to confirm they still work (tested on version: 6.0-alpha6)
- [x] Any links I added or changed work (no 404s)
- [/] Any images or tables I added display correctly
- [x] I checked spelling/grammar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CaMTBRfjP8gEHzbiFYLkCf
