### PR TITLE
Add automerge label workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types:
       - labeled
+      - unlabeled
 
 permissions:
   contents: write
@@ -16,9 +17,20 @@ jobs:
       github.repository == 'JabRef/user-documentation' &&
       github.event.pull_request.head.repo.full_name == 'JabRef/user-documentation'
     runs-on: ubuntu-slim
+    # Serialize label events per PR so a quick add/remove applies in order.
+    concurrency:
+      group: automerge-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
     steps:
-      - name: Merge PR
+      - name: Enable auto-merge
+        if: github.event.action == 'labeled'
         run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Disable auto-merge
+        if: github.event.action == 'unlabeled'
+        run: gh pr merge --disable-auto "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,24 @@
+name: Auto Merge
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    if: >
+      github.event.label.name == 'automerge' &&
+      github.repository == 'JabRef/user-documentation' &&
+      github.event.pull_request.head.repo.full_name == 'JabRef/user-documentation'
+    runs-on: ubuntu-slim
+    steps:
+      - name: Merge PR
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Low-risk CI update: labeling a PR from this repository with `automerge` enables squash auto-merge, so it merges once the required checks are green, like in JabRef/jabref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KETjisR38ZQweRZ62USseC